### PR TITLE
Add a nodejs::multi recipe to install nvm, a node version manager.

### DIFF
--- a/vagrant_base/nodejs/attributes/multi.rb
+++ b/vagrant_base/nodejs/attributes/multi.rb
@@ -1,0 +1,3 @@
+default[:nodejs][:versions]   = ["0.4.11", "0.5.5"]
+default[:nodejs][:aliases]    = {"0.5.5".to_sym => "latest", "0.4.11".to_sym => "stable"}
+default[:nodejs][:default]    = "0.4.11"

--- a/vagrant_base/nodejs/files/default/nvm.sh
+++ b/vagrant_base/nodejs/files/default/nvm.sh
@@ -1,0 +1,301 @@
+# Node Version Manager
+# Implemented as a bash function
+# To use source this file from your bash profile
+#
+# Implemented by Tim Caswell <tim@creationix.com>
+# with much bash help from Matthew Ranney
+
+# Auto detect the NVM_DIR
+if [ ! -d "$NVM_DIR" ]; then
+    export NVM_DIR=$(cd $(dirname ${BASH_SOURCE[0]:-$0}); pwd)
+fi
+
+# Emulate curl with wget, if necessary
+if [ ! `which curl` ]; then
+    if [ `which wget` ]; then
+        curl() {
+            ARGS="$* "
+            ARGS=${ARGS/-s /-q }
+            ARGS=${ARGS/--progress-bar /}
+            ARGS=${ARGS/-C - /-c }
+            ARGS=${ARGS/-o /-O }
+
+            wget $ARGS
+        }
+    else
+        NOCURL='nocurl'
+        curl() { echo 'Need curl or wget to proceed.' >&2; }
+    fi
+fi
+
+# Expand a version using the version cache
+nvm_version()
+{
+    PATTERN=$1
+    VERSION=''
+    if [ -f "$NVM_DIR/alias/$PATTERN" ]; then
+        nvm_version `cat $NVM_DIR/alias/$PATTERN`
+        return
+    fi
+    # If it looks like an explicit version, don't do anything funny
+    if [[ "$PATTERN" == v*.*.* ]]; then
+        VERSION="$PATTERN"
+    fi
+    # The default version is the current one
+    if [ ! "$PATTERN" -o "$PATTERN" = 'current' ]; then
+        VERSION=`node -v 2>/dev/null`
+    fi
+    if [ "$PATTERN" = 'stable' ]; then
+        PATTERN='*.*[02468].'
+    fi
+    if [ "$PATTERN" = 'latest' ]; then
+        PATTERN='*.*.'
+    fi
+    if [ "$PATTERN" = 'all' ]; then
+        (cd $NVM_DIR; \ls -dG v* 2>/dev/null || echo "N/A")
+        return
+    fi
+    if [ ! "$VERSION" ]; then
+        VERSION=`(cd $NVM_DIR; \ls -d v${PATTERN}* 2>/dev/null) | sort -t. -k 2,1n -k 2,2n -k 3,3n | tail -n1`
+    fi
+    if [ ! "$VERSION" ]; then
+        echo "N/A"
+        return 13
+    elif [ -e "$NVM_DIR/$VERSION" ]; then
+        (cd $NVM_DIR; \ls -dG "$VERSION")
+    else
+        echo "$VERSION"
+    fi
+}
+
+nvm()
+{
+  if [ $# -lt 1 ]; then
+    nvm help
+    return
+  fi
+  case $1 in
+    "help" )
+      echo
+      echo "Node Version Manager"
+      echo
+      echo "Usage:"
+      echo "    nvm help                    Show this message"
+      echo "    nvm install <version>       Download and install a <version>"
+      echo "    nvm uninstall <version>     Uninstall a version"
+      echo "    nvm use <version>           Modify PATH to use <version>"
+      echo "    nvm ls                      List versions (installed versions are blue)"
+      echo "    nvm ls <version>            List versions matching a given description"
+      echo "    nvm deactivate              Undo effects of NVM on current shell"
+      echo "    nvm sync                    Update the local cache of available versions"
+      echo "    nvm alias [<pattern>]       Show all aliases beginning with <pattern>"
+      echo "    nvm alias <name> <version>  Set an alias named <name> pointing to <version>"
+      echo "    nvm unalias <name>          Deletes the alias named <name>"
+      echo "    nvm copy-packages <version> Install global NPM packages contained in <version> to current version"
+      echo
+      echo "Example:"
+      echo "    nvm install v0.4.0          Install a specific version number"
+      echo "    nvm use stable              Use the stable release"
+      echo "    nvm install latest          Install the latest, possibly unstable version"
+      echo "    nvm use 0.2                 Use the latest available 0.2.x release"
+      echo "    nvm alias default v0.4.0    Set v0.4.0 as the default"
+      echo
+    ;;
+    "install" )
+      if [ $# -ne 2 ]; then
+        nvm help
+        return
+      fi
+      [ "$NOCURL" ] && curl && return
+      VERSION=`nvm_version $2`
+      tarball=''
+      if [ "`curl -Is "http://nodejs.org/dist/$VERSION/node-$VERSION.tar.gz" | grep '200 OK'`" != '' ]; then
+        tarball="http://nodejs.org/dist/$VERSION/node-$VERSION.tar.gz"
+      elif [ "`curl -Is "http://nodejs.org/dist/node-$VERSION.tar.gz" | grep '200 OK'`" != '' ]; then
+        tarball="http://nodejs.org/dist/node-$VERSION.tar.gz"
+      fi
+      if (
+        [ ! -z $tarball ] && \
+        mkdir -p "$NVM_DIR/src" && \
+        cd "$NVM_DIR/src" && \
+        curl -C - --progress-bar $tarball -o "node-$VERSION.tar.gz" && \
+        tar -xzf "node-$VERSION.tar.gz" && \
+        cd "node-$VERSION" && \
+        ./configure --prefix="$NVM_DIR/$VERSION" && \
+        make && \
+        rm -f "$NVM_DIR/$VERSION" 2>/dev/null && \
+        make install
+        )
+      then
+        nvm use $VERSION
+        if ! which npm ; then
+          echo "Installing npm..."
+          # TODO: if node version 0.2.x add npm_install=0.2.19 before sh
+          curl http://npmjs.org/install.sh | clean=yes sh
+        fi
+      else
+        echo "nvm: install $VERSION failed!"
+      fi
+    ;;
+    "uninstall" )
+      [ $# -ne 2 ] && nvm help && return
+      if [[ $2 == `nvm_version` ]]; then
+        echo "nvm: Cannot uninstall currently-active node version, $2."
+        return
+      fi
+      VERSION=`nvm_version $2`
+      if [ ! -d $NVM_DIR/$VERSION ]; then
+        echo "$VERSION version is not installed yet"
+        return;
+      fi
+
+      # Delete all files related to target version.
+      (cd "$NVM_DIR" && \
+          rm -rf "node-$VERSION" 2>/dev/null && \
+          mkdir -p "$NVM_DIR/src" && \
+          cd "$NVM_DIR/src" && \
+          rm -f "node-$VERSION.tar.gz" 2>/dev/null && \
+          rm -rf "$NVM_DIR/$VERSION" 2>/dev/null)
+      echo "Uninstalled node $VERSION"
+
+      # Rm any aliases that point to uninstalled version.
+      for A in `grep -l $VERSION $NVM_DIR/alias/*`
+      do
+        nvm unalias `basename $A`
+      done
+
+      # Run sync in order to restore version stub file in $NVM_DIR.
+      nvm sync 1>/dev/null
+    ;;
+    "deactivate" )
+      if [[ $PATH == *$NVM_DIR/*/bin* ]]; then
+        export PATH=${PATH%$NVM_DIR/*/bin*}${PATH#*$NVM_DIR/*/bin:}
+        hash -r
+        echo "$NVM_DIR/*/bin removed from \$PATH"
+      else
+        echo "Could not find $NVM_DIR/*/bin in \$PATH"
+      fi
+      if [[ $MANPATH == *$NVM_DIR/*/share/man* ]]; then
+        export MANPATH=${MANPATH%$NVM_DIR/*/share/man*}${MANPATH#*$NVM_DIR/*/share/man:}
+        echo "$NVM_DIR/*/share/man removed from \$MANPATH"
+      else
+        echo "Could not find $NVM_DIR/*/share/man in \$MANPATH"
+      fi
+    ;;
+    "use" )
+      if [ $# -ne 2 ]; then
+        nvm help
+        return
+      fi
+      VERSION=`nvm_version $2`
+      if [ ! -d $NVM_DIR/$VERSION ]; then
+        echo "$VERSION version is not installed yet"
+        return;
+      fi
+      if [[ $PATH == *$NVM_DIR/*/bin* ]]; then
+        PATH=${PATH%$NVM_DIR/*/bin*}$NVM_DIR/$VERSION/bin${PATH#*$NVM_DIR/*/bin}
+      else
+        PATH="$NVM_DIR/$VERSION/bin:$PATH"
+      fi
+      if [[ $MANPATH == *$NVM_DIR/*/share/man* ]]; then
+        MANPATH=${MANPATH%$NVM_DIR/*/share/man*}$NVM_DIR/$VERSION/share/man${MANPATH#*$NVM_DIR/*/share/man}
+      else
+        MANPATH="$NVM_DIR/$VERSION/share/man:$MANPATH"
+      fi
+      export PATH
+      hash -r
+      export MANPATH
+      export NVM_PATH="$NVM_DIR/$VERSION/lib/node"
+      export NVM_BIN="$NVM_DIR/$VERSION/bin"
+      echo "Now using node $VERSION"
+    ;;
+    "ls" )
+      if [ $# -ne 1 ]; then
+        nvm_version $2
+        return
+      fi
+      nvm_version all
+      for P in {stable,latest,current}; do
+          echo -ne "$P: \t"; nvm_version $P
+      done
+      nvm alias
+      echo "# use 'nvm sync' to update from nodejs.org"
+    ;;
+    "alias" )
+      mkdir -p $NVM_DIR/alias
+      if [ $# -le 2 ]; then
+        (cd $NVM_DIR/alias && for ALIAS in `\ls $2* 2>/dev/null`; do
+            DEST=`cat $ALIAS`
+            VERSION=`nvm_version $DEST`
+            if [ "$DEST" = "$VERSION" ]; then
+                echo "$ALIAS -> $DEST"
+            else
+                echo "$ALIAS -> $DEST (-> $VERSION)"
+            fi
+        done)
+        return
+      fi
+      if [ ! "$3" ]; then
+          rm -f $NVM_DIR/alias/$2
+          echo "$2 -> *poof*"
+          return
+      fi
+      mkdir -p $NVM_DIR/alias
+      VERSION=`nvm_version $3`
+      if [ $? -ne 0 ]; then
+        echo "! WARNING: Version '$3' does not exist." >&2
+      fi
+      echo $3 > "$NVM_DIR/alias/$2"
+      if [ ! "$3" = "$VERSION" ]; then
+          echo "$2 -> $3 (-> $VERSION)"
+          echo "! WARNING: Moving target. Aliases to implicit versions may change without warning."
+      else
+        echo "$2 -> $3"
+      fi
+    ;;
+    "unalias" )
+      mkdir -p $NVM_DIR/alias
+      [ $# -ne 2 ] && nvm help && return
+      [ ! -f $NVM_DIR/alias/$2 ] && echo "Alias $2 doesn't exist!" && return
+      rm -f $NVM_DIR/alias/$2
+      echo "Deleted alias $2"
+    ;;
+    "sync" )
+        [ "$NOCURL" ] && curl && return
+        LATEST=`nvm_version latest`
+        STABLE=`nvm_version stable`
+        (cd $NVM_DIR
+        rm -f v* 2>/dev/null
+        printf "# syncing with nodejs.org..."
+        for VER in `curl -s http://nodejs.org/dist/ -o - | grep 'v[0-9].*' | sed -e 's/.*node-//' -e 's/\.tar\.gz.*//' -e 's/<[^>]*>//' -e 's/\/<[^>]*>.*//'`; do
+            touch $VER
+        done
+        echo " done."
+        )
+        [ "$STABLE" = `nvm_version stable` ] || echo "NEW stable: `nvm_version stable`"
+        [ "$LATEST" = `nvm_version latest` ] || echo "NEW latest: `nvm_version latest`"
+    ;;
+    "copy-packages" )
+        if [ $# -ne 2 ]; then
+          nvm help
+          return
+        fi
+        VERSION=`nvm_version $2`
+        ROOT=`nvm use $VERSION && npm -g root`
+        INSTALLS=`nvm use $VERSION > /dev/null && npm -g -p ll | grep "$ROOT\/[^/]\+$" | cut -d '/' -f 8 | cut -d ":" -f 2 | grep -v npm | tr "\n" " "`
+        npm install -g $INSTALLS
+    ;;
+    "clear-cache" )
+        rm -f $NVM_DIR/v* 2>/dev/null
+        echo "Cache cleared."
+    ;;
+    "version" )
+        nvm_version $2
+    ;;
+    * )
+      nvm help
+    ;;
+  esac
+}
+
+nvm ls default >/dev/null 2>&1 && nvm use default >/dev/null

--- a/vagrant_base/nodejs/files/default/profile_entry.sh
+++ b/vagrant_base/nodejs/files/default/profile_entry.sh
@@ -1,0 +1,3 @@
+export NVM_DIR=/home/vagrant/.nvm
+export PATH="./node_modules/.bin":$PATH
+. /home/vagrant/.nvm/nvm.sh

--- a/vagrant_base/nodejs/recipes/multi.rb
+++ b/vagrant_base/nodejs/recipes/multi.rb
@@ -1,0 +1,68 @@
+#
+# Cookbook Name:: node.js
+# Recipe:: n
+# Copyright 2011, Travis CI development team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require "tmpdir"
+
+permissions_setup = Proc.new do |resource|
+  resource.owner "vagrant"
+  resource.group "vagrant"
+  resource.mode 0755
+end
+
+directory "/home/vagrant/.nvm" do
+  permissions_setup.call(self)
+end
+
+# Note that nvm will automatically install npm, the node package manager,
+# for each installed version of node.
+cookbook_file "/home/vagrant/.nvm/nvm.sh" do
+  permissions_setup.call(self)
+end
+
+cookbook_file "/etc/profile.d/nvm.sh" do
+  permissions_setup.call(self)
+  source "profile_entry.sh"
+end
+
+nvm = "source /home/vagrant/.nvm/nvm.sh; nvm"
+
+node[:nodejs][:versions].each do |node|
+  bash "installing node version #{node}" do
+    Chef::Log.info("Installing node v#{node}")
+    user "vagrant"
+    not_if  "ls -l /home/vagrant/.nvm | grep \"^d\" | grep #{node}"
+    code  "#{nvm} install v#{node}"
+  end
+end
+
+bash "make the default node" do
+  user "vagrant"
+  code "#{nvm} alias default v#{node[:default]}"
+end
+
+node[:nodejs][:aliases].each do |existing_name, new_name|
+  bash "alias node #{existing_name} => #{new_name}" do
+    user "vagrant"
+    code "#{nvm} alias #{new_name} v#{existing_name}"
+  end
+end


### PR DESCRIPTION
This adds an `nvm` command which can be used similarly to `rvm` in the upcoming `Travis::Worker::Builders::NodeJs` to run builds across a matrix of different node.js versions. 
- Add nodejs::multi recipe for nvm, a node.js version manager. 
- Add attributes for specifying which node versions to install.
