### PR TITLE
Introducing libossp-uuid-dev cookbook which is a dependency of the uuid4r

### DIFF
--- a/vagrant_base/libossp-uuid-dev/recipes/default.rb
+++ b/vagrant_base/libossp-uuid-dev/recipes/default.rb
@@ -1,0 +1,4 @@
+case node[:platform]
+when "ubuntu", "debian"
+  package "libossp-uuid-dev"
+end


### PR DESCRIPTION
tested and working under Ubuntu 10.04.2 LTS and Debian Lenny 4.0.
The library is a dependency of the uuid4r gem. Discussed with @michaelklishin and @chrisharper

cheers :-)
