### PR TITLE
Update nodejs::multi for better aliases and v0.6.0.

### DIFF
--- a/vagrant_base/nodejs/attributes/multi.rb
+++ b/vagrant_base/nodejs/attributes/multi.rb
@@ -1,3 +1,3 @@
-default[:nodejs][:versions]   = ["0.4.12", "0.5.8"]
-default[:nodejs][:aliases]    = {"0.5.8".to_sym => "latest", "0.4.12".to_sym => "stable"}
+default[:nodejs][:versions]   = ["0.4.12", "0.5.10", "0.6.0"]
+default[:nodejs][:aliases]    = {"0.5.10".to_sym => "0.5", "0.4.12".to_sym => "0.4", "0.6.0".to_sym => "0.6"}
 default[:nodejs][:default]    = "0.4.12"


### PR DESCRIPTION
- Install node v0.6.0, v0.5.10, v0.4.12
- Alias the above versions as 0.6, 0.5, 0.4 respectively. 
