### PR TITLE
[PHP] Updating last PHP RC (5.4.0rc2)

### DIFF
--- a/vagrant_base/php/attributes/default.rb
+++ b/vagrant_base/php/attributes/default.rb
@@ -1,2 +1,2 @@
-default[:php][:multi][:versions] = ["5.3.8", "5.4.0RC1"]
-default[:php][:multi][:aliases] = {"5.2" => "5.2.17", "5.3" => "5.3.8", "5.4" => "5.4.0RC1"}
+default[:php][:multi][:versions] = ["5.3.8", "5.4.0RC2"]
+default[:php][:multi][:aliases] = {"5.2" => "5.2.17", "5.3" => "5.3.8", "5.4" => "5.4.0RC2"}


### PR DESCRIPTION
Tested on my vagrant/sous-chef install :

```
debian31:sous-chef ayoub$ vagrant ssh
vagrant@natty32:~$ phpenv global php-5.4
vagrant@natty32:~$ php -v
PHP 5.4.0RC2 (cli) (built: Nov 25 2011 23:46:12) (DEBUG)
Copyright (c) 1997-2011 The PHP Group
Zend Engine v2.4.0, Copyright (c) 1998-2011 Zend Technologies
```
