### PR TITLE
PhantomJS 1.5.0

### DIFF
--- a/ci_environment/phantomjs/attributes/default.rb
+++ b/ci_environment/phantomjs/attributes/default.rb
@@ -1,4 +1,4 @@
-version = "1.4.1"
+version = "1.5.0"
 
 default[:phantomjs] = {
   :version => version,

--- a/ci_environment/phantomjs/recipes/tarball.rb
+++ b/ci_environment/phantomjs/recipes/tarball.rb
@@ -33,7 +33,7 @@ tarball_dir = File.join(td, "phantomjs")
 remote_file(tmp) do
   source node.phantomjs.tarball.url
 
-  not_if "which phantomjs"
+  not_if "which phantomjs && [[ `phantomjs --version` == \"#{node.phantomjs.version}\" ]]"
 end
 
 # 2. Extract it


### PR DESCRIPTION
The not_if will trigger the download on PhantomJS 1.4.1 due to the lack of a running X server causing `phantomjs --version` to fail.

PhantomJS 1.5.0 is completely headless, so once it is installed, the `phantomjs --version` will succeed despite there being no running X server.
