### PR TITLE
Add scripts for deploying CMake and mingw32

### DIFF
--- a/ci_environment/cmake/README.md
+++ b/ci_environment/cmake/README.md
@@ -1,0 +1,21 @@
+DESCRIPTION
+===========
+
+Installs CMake.
+
+LICENSE AND AUTHOR
+==================
+
+Author:: Scott J. Goldman (<scottjgo@gmail.com>)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ci_environment/cmake/metadata.rb
+++ b/ci_environment/cmake/metadata.rb
@@ -1,0 +1,10 @@
+maintainer        "Scott J. Goldman"
+maintainer_email  "scottjgo@gmail.com"
+license           "Apache 2.0"
+description       "Installs CMake"
+version           "1.0.0"
+recipe            "cmake", "Installs CMake"
+
+%w{ ubuntu debian }.each do |os|
+  supports os
+end

--- a/ci_environment/cmake/recipes/default.rb
+++ b/ci_environment/cmake/recipes/default.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: mingw32
+# Recipe:: default
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['platform']
+when "ubuntu","debian"
+  package 'cmake' do
+    action :install
+  end
+end

--- a/ci_environment/mingw32/README.md
+++ b/ci_environment/mingw32/README.md
@@ -1,0 +1,21 @@
+DESCRIPTION
+===========
+
+Installs packages for cross-compiling 32-bit Windows applications in C.
+
+LICENSE AND AUTHOR
+==================
+
+Author:: Scott J. Goldman (<scottjgo@gmail.com>)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ci_environment/mingw32/metadata.rb
+++ b/ci_environment/mingw32/metadata.rb
@@ -1,0 +1,10 @@
+maintainer        "Scott J. Goldman"
+maintainer_email  "scottjgo@gmail.com"
+license           "Apache 2.0"
+description       "Installs 32-bit MINGW C cross-compiler / build tools"
+version           "1.0.0"
+recipe            "mingw", "Installs 32-bit MINGW C cross-compiler and build tools on Linux"
+
+%w{ ubuntu debian }.each do |os|
+  supports os
+end

--- a/ci_environment/mingw32/recipes/default.rb
+++ b/ci_environment/mingw32/recipes/default.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: mingw32
+# Recipe:: default
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['platform']
+when "ubuntu","debian"
+  package 'mingw32' do
+    action :install
+  end
+end


### PR DESCRIPTION
For testing the libgit2 windows build, it would be nice if the travis-ci
build VMs had mingw32. It seems to take too long to download/install
sometimes with the slow german ubuntu mirror, or we could just install it
as part of our .travis.yml.

Since we're adding mingw32 anyway, might as well CMake which is also
required for building libgit2.

/cc @benstraub @arrbee @tanoku

p.s. travis guys, if you're willing to take these scripts, what else do i need to update so that future travis-ci build VMs will actually use these new chef scripts?
