### PR TITLE
Update php-build to get Xdebug 2.2.0 definition.

### DIFF
--- a/ci_environment/phpbuild/attributes/default.rb
+++ b/ci_environment/phpbuild/attributes/default.rb
@@ -1,5 +1,5 @@
 default[:phpbuild][:git][:repository]                  = "git://github.com/CHH/php-build.git"
-default[:phpbuild][:git][:revision]                    = "16f6212df2603dd85c7952bd29d986f720cf5782"
+default[:phpbuild][:git][:revision]                    = "1e9df7cd90a8e8443eabd0d63daa571c873b09ce"
 default[:phpbuild][:phpunit_plugin][:git][:repository] = "git://github.com/CHH/php-build-plugin-phpunit.git"
 default[:phpbuild][:phpunit_plugin][:git][:revision]   = "a6a5ce4a5126b90a02dd473b63f660515de7d183"
 


### PR DESCRIPTION
The reference is the same of 0.7.0 tag
