### PR TITLE
Introduce global Composer for php-build's

### DIFF
--- a/ci_environment/phpbuild/attributes/default.rb
+++ b/ci_environment/phpbuild/attributes/default.rb
@@ -1,7 +1,11 @@
-default[:phpbuild][:git][:repository]                  = "git://github.com/CHH/php-build.git"
-default[:phpbuild][:git][:revision]                    = "893a8a113e73b16f69fa3b2d74b92c249810aca2"
-default[:phpbuild][:phpunit_plugin][:git][:repository] = "git://github.com/CHH/php-build-plugin-phpunit.git"
-default[:phpbuild][:phpunit_plugin][:git][:revision]   = "a6a5ce4a5126b90a02dd473b63f660515de7d183"
+default[:phpbuild][:git][:repository]                      = "git://github.com/CHH/php-build.git"
+default[:phpbuild][:git][:revision]                        = "893a8a113e73b16f69fa3b2d74b92c249810aca2"
+default[:phpbuild][:plugins][:phpunit][:git][:repository]  = "git://github.com/CHH/php-build-plugin-phpunit.git"
+default[:phpbuild][:plugins][:phpunit][:git][:revision]    = "a6a5ce4a5126b90a02dd473b63f660515de7d183"
+default[:phpbuild][:plugins][:phpunit][:php_versions]      = ["5.2", "5.3", "5.4"]
+default[:phpbuild][:plugins][:composer][:git][:repository] = "git://github.com/stloyd/php-build-plugin-composer.git"
+default[:phpbuild][:plugins][:composer][:git][:revision]   = "8bc5a0100a67908f10875e0bf1a9c10796271362"
+default[:phpbuild][:plugins][:composer][:php_versions]     = ["5.3", "5.4"]
 
-default[:phpbuild][:custom][:php_ini][:memory_limit]  = "512M"
-default[:phpbuild][:custom][:php_ini][:timezone]      = "UTC"
+default[:phpbuild][:custom][:php_ini][:memory_limit]       = "512M"
+default[:phpbuild][:custom][:php_ini][:timezone]           = "UTC"

--- a/ci_environment/phpbuild/recipes/default.rb
+++ b/ci_environment/phpbuild/recipes/default.rb
@@ -48,8 +48,16 @@ end
 git "/tmp/php-build-plugin-phpunit" do
   user       node.travis_build_environment.user
   group      node.travis_build_environment.group
-  repository node[:phpbuild][:phpunit_plugin][:git][:repository]
-  revision   node[:phpbuild][:phpunit_plugin][:git][:revision]
+  repository node[:phpbuild][:plugins][:phpunit][:git][:repository]
+  revision   node[:phpbuild][:plugins][:phpunit][:git][:revision]
+  action     :checkout
+end
+
+git "/tmp/php-build-plugin-composer" do
+  user       node.travis_build_environment.user
+  group      node.travis_build_environment.group
+  repository node[:phpbuild][:plugins][:composer][:git][:repository]
+  revision   node[:phpbuild][:plugins][:composer][:git][:revision]
   action     :checkout
 end
 
@@ -67,13 +75,19 @@ directory "#{phpbuild_path}/tmp" do
   action :create
 end
 
-bash "install php-build plugins" do
-  user   node.travis_build_environment.user
-  group  node.travis_build_environment.group
-  code <<-EOF
-  cp /tmp/php-build-plugin-phpunit/share/php-build/after-install.d/phpunit #{phpbuild_path}/share/php-build/after-install.d
-  EOF
-  not_if "test -f #{phpbuild_path}/share/php-build/after-install.d/phpunit"
+node.phpbuild.plugins.each do |plugin_name, plugin_data|
+  node.php.multi.aliases.each do |short_version, target_version|
+    if plugin_data[:php_versions].include? short_version then
+      bash "install php-build plugins" do
+        user   node.travis_build_environment.user
+        group  node.travis_build_environment.group
+        code <<-EOF
+        cp /tmp/php-build-plugin-#{plugin_name}/share/php-build/after-install.d/#{plugin_name} #{phpbuild_path}/share/php-build/after-install.d
+        EOF
+        not_if "test -f #{phpbuild_path}/share/php-build/after-install.d/#{plugin_name}"
+      end
+    end
+  end
 end
 
 template "#{phpbuild_path}/share/php-build/default_configure_options" do


### PR DESCRIPTION
Hey,

I'm not to good with Ruby (read: I don't know anything in it, and this is my first code in it =)), but I wanted to introduce an global [Composer](http://getcomposer.org/) instance, for PHP build.

Reason for this is because most of PHP libraries use Composer to manage deps when testing on Travis-CI, and they need to download this all the time. This solves the problem (at least tries =)) same way as PHPUnit is downloaded.

Hope I didn't done too many stupid mistakes in this code =)

Feedback is really welcome =D
