### PR TITLE
Suppress PostgreSQL client warning messages in build output

### DIFF
--- a/ci_environment/postgresql/attributes/default.rb
+++ b/ci_environment/postgresql/attributes/default.rb
@@ -69,3 +69,6 @@ default[:sysctl][:kernel_shmall] = 32768
 default[:sysctl][:kernel_shmmax] = 134217728
 
 default[:postgresql][:max_connections] = 512
+
+# suppress warning output from build clients
+default[:postgresql][:client_min_messages] = "error"

--- a/ci_environment/postgresql/templates/default/debian.postgresql.conf.erb
+++ b/ci_environment/postgresql/templates/default/debian.postgresql.conf.erb
@@ -143,7 +143,8 @@ max_fsm_pages = 153600                  # min max_fsm_relations*16, 6 bytes each
 
 # - When to Log -
 
-#client_min_messages = notice           # values in order of decreasing detail:
+client_min_messages = <%= node.postgresql.client_min_messages %>
+                                        # values in order of decreasing detail:
                                         #   debug5
                                         #   debug4
                                         #   debug3

--- a/ci_environment/postgresql/templates/default/redhat.postgresql.conf.erb
+++ b/ci_environment/postgresql/templates/default/redhat.postgresql.conf.erb
@@ -62,7 +62,7 @@
                                         # (change requires restart)
 #port = 5432                            # (change requires restart)
 max_connections = 100                   # (change requires restart)
-# Note:  Increasing max_connections costs ~400 bytes of shared memory per 
+# Note:  Increasing max_connections costs ~400 bytes of shared memory per
 # connection slot, plus lock space (see max_locks_per_transaction).
 #superuser_reserved_connections = 3     # (change requires restart)
 #unix_socket_directory = ''             # (change requires restart)
@@ -150,7 +150,7 @@ shared_buffers = 32MB                   # min 128kB
 
 #fsync = on                             # turns forced synchronization on or off
 #synchronous_commit = on                # immediate fsync at commit
-#wal_sync_method = fsync                # the default is the first option 
+#wal_sync_method = fsync                # the default is the first option
                                         # supported by the operating system:
                                         #   open_datasync
                                         #   fdatasync
@@ -221,7 +221,7 @@ shared_buffers = 32MB                   # min 128kB
 #constraint_exclusion = partition       # on, off, or partition
 #cursor_tuple_fraction = 0.1            # range 0.0-1.0
 #from_collapse_limit = 8
-#join_collapse_limit = 8                # 1 disables collapsing of explicit 
+#join_collapse_limit = 8                # 1 disables collapsing of explicit
                                         # JOIN clauses
 
 
@@ -257,7 +257,7 @@ log_truncate_on_rotation = on           # If on, an existing log file of the
                                         # in all cases.
 log_rotation_age = 1d                   # Automatic rotation of logfiles will
                                         # happen after that time.  0 disables.
-log_rotation_size = 0                   # Automatic rotation of logfiles will 
+log_rotation_size = 0                   # Automatic rotation of logfiles will
                                         # happen after that much log output.
                                         # 0 disables.
 
@@ -273,7 +273,8 @@ log_rotation_size = 0                   # Automatic rotation of logfiles will
 
 # - When to Log -
 
-#client_min_messages = notice           # values in order of decreasing detail:
+client_min_messages = <%= node.postgresql.client_min_messages %>
+                                        # values in order of decreasing detail:
                                         #   debug5
                                         #   debug4
                                         #   debug3
@@ -384,7 +385,7 @@ log_rotation_size = 0                   # Automatic rotation of logfiles will
 # AUTOVACUUM PARAMETERS
 #------------------------------------------------------------------------------
 
-#autovacuum = on                        # Enable autovacuum subprocess?  'on' 
+#autovacuum = on                        # Enable autovacuum subprocess?  'on'
                                         # requires track_counts to also be on.
 #log_autovacuum_min_duration = -1       # -1 disables, 0 logs all actions and
                                         # their durations, > 0 logs only
@@ -394,7 +395,7 @@ log_rotation_size = 0                   # Automatic rotation of logfiles will
 #autovacuum_naptime = 1min              # time between autovacuum runs
 #autovacuum_vacuum_threshold = 50       # min number of row updates before
                                         # vacuum
-#autovacuum_analyze_threshold = 50      # min number of row updates before 
+#autovacuum_analyze_threshold = 50      # min number of row updates before
                                         # analyze
 #autovacuum_vacuum_scale_factor = 0.2   # fraction of table size before vacuum
 #autovacuum_analyze_scale_factor = 0.1  # fraction of table size before analyze


### PR DESCRIPTION
This is a small patch that will remove `WARNING`-level messages from the build output. I have seen builds with 3,000+ lines of output like:

```
WARNING:  there is already a transaction in progress
```

This output has no bearing on the return value of the tests and puts a tremendous burden on the AJAX UI to render all of that output. Output levels can still be controlled via client configuration options.
