### PR TITLE
Make all ids unique in maven config.

### DIFF
--- a/ci_environment/maven3/files/default/settings.xml
+++ b/ci_environment/maven3/files/default/settings.xml
@@ -40,7 +40,7 @@
         </repository>
 
         <repository>
-          <id>sonatype</id>
+          <id>sonatype-apache</id>
           <name>Apache repo (releases)</name>
           <releases>
             <enabled>true</enabled>


### PR DESCRIPTION
I was getting the following warnings when using maven on travis-ci.org:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective settings
[WARNING] 'profiles.profile[standard-with-extra-repos].repositories.repository.id' must be unique but found duplicate repository with id sonatype @ /home/travis/.m2/settings.xml
[WARNING] 
```

My theory is that you have two repositories with the same id, thus throwing this error. My theory is based off of the warning and [this doc page](http://maven.apache.org/guides/mini/guide-multiple-repositories.html).

Thanks,
/Nat
