### PR TITLE
Use `travis_build_environment.home` as NVM_DIR

### DIFF
--- a/ci_environment/nodejs/recipes/multi.rb
+++ b/ci_environment/nodejs/recipes/multi.rb
@@ -42,9 +42,9 @@ cookbook_file "#{node.travis_build_environment.home}/.nvm/nvm.sh" do
   permissions_setup.call(self)
 end
 
-cookbook_file "/etc/profile.d/nvm.sh" do
+template "/etc/profile.d/nvm.sh" do
   permissions_setup.call(self)
-  source "profile_entry.sh"
+  source "nvm.sh.erb"
 end
 
 nvm = "source #{node.travis_build_environment.home}/.nvm/nvm.sh; nvm"

--- a/ci_environment/nodejs/templates/default/nvm.sh.erb
+++ b/ci_environment/nodejs/templates/default/nvm.sh.erb
@@ -1,0 +1,3 @@
+export NVM_DIR=<%= node.travis_build_environment.home %>/.nvm
+export PATH="./node_modules/.bin":$PATH
+. $NVM_DIR/nvm.sh


### PR DESCRIPTION
Setting up nvm in a non-Vagrant environment fails due to hardcoded `/home/vagrant`,
so this sets NVM_DIR as whatever the travis_build_environment recipe
uses for its home directory.

/cc @mkocher @ohrite @briancunnie
