### PR TITLE
Bump go to 1.0.3

### DIFF
--- a/ci_environment/golang/attributes/default.rb
+++ b/ci_environment/golang/attributes/default.rb
@@ -2,10 +2,10 @@ default[:golang] = {
   # can be "stable" or "tip"
   :version => "stable",
   :multi => {
-    :versions => %w(go1.0.2),
-    :default_version  => "go1.0.2",
+    :versions => %w(go1.0.3),
+    :default_version  => "go1.0.3",
     :aliases => {
-      "go1" => "go1.0.2"
+      "go1" => "go1.0.3"
     }
   }
 }


### PR DESCRIPTION
Go 1.0.3 is the latest bugfix release of Go1, and is available in the gophers ubuntu repository.
Looks like all you need to support it, is to change a number, here it is.
