### PR TITLE
Add metadata to xserver cookbook

### DIFF
--- a/ci_environment/phantomjs/metadata.rb
+++ b/ci_environment/phantomjs/metadata.rb
@@ -1,0 +1,3 @@
+maintainer       "Travis CI Development Team"
+license          "Apache v2.0'"
+description      "Installs/Configures phantomjs"

--- a/ci_environment/xserver/metadata.rb
+++ b/ci_environment/xserver/metadata.rb
@@ -1,0 +1,3 @@
+maintainer       "Travis CI Development Team"
+license          "Apache v2.0'"
+description      "Installs/Configures xserver"


### PR DESCRIPTION
Librarian requires metadata.rb in order to use the cookbook, and I
needed it in order to use xserver in my own project :)
