### PR TITLE
Change shebang on mongodb init script to bash

### DIFF
--- a/ci_environment/mongodb/files/default/mongodb.sysvinit.sh
+++ b/ci_environment/mongodb/files/default/mongodb.sysvinit.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # init.d script with LSB support.
 #


### PR DESCRIPTION
The initscript uses [[, which is only available on bash, not sh.

This should fix travis-ci/travis-ci#788.

Sorry for the somewhat ugly commit history, I've been doing too many simple pull requests with the GitHub online "Edit" button, and forgot that it actually just commits to the repo if you have a commit bit set.
