### PR TITLE
Bump elasticsearch to 0.20.2.

### DIFF
--- a/ci_environment/elasticsearch/attributes/default.rb
+++ b/ci_environment/elasticsearch/attributes/default.rb
@@ -1,5 +1,5 @@
 default[:elasticsearch] = {
-  :version => "0.20.1",
+  :version => "0.20.2",
   :service => {
     :enabled => false
   }


### PR DESCRIPTION
The bump from 0.19 to 0.20.1 in https://github.com/travis-ci/travis-cookbooks/commit/96b3b6fe0a3598de72f71b80f4a97cb0c475534d breaks one of my builds. 

This is an elasticsearch bug that I've confirmed has been fixed in [0.20.2](http://www.elasticsearch.org/download/2012/12/27/0.20.2.html), and I'd much appreciate an update.
