### PR TITLE
[WIP] Setup base configuration for Composer

### DIFF
--- a/ci_environment/composer/attributes/default.rb
+++ b/ci_environment/composer/attributes/default.rb
@@ -1,0 +1,3 @@
+default[:config] = {
+  :github_oauth_token => "TRAVIS-READ-ONLY-TOKEN-HERE"
+}

--- a/ci_environment/composer/files/default/composer.sh
+++ b/ci_environment/composer/files/default/composer.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export COMPOSER_HOME=$HOME

--- a/ci_environment/composer/recipes/default.rb
+++ b/ci_environment/composer/recipes/default.rb
@@ -1,6 +1,7 @@
 include_recipe "php::multi"
 
-phpenv_path = File.join(node.travis_build_environment.home, ".phpenv")
+phpenv_path   = File.join(node.travis_build_environment.home, ".phpenv")
+composer_path = "#{node.travis_build_environment.home}/.composer"
 
 node[:php][:multi][:versions].each do |php_version|
   bin_path = "#{phpenv_path}/versions/#{php_version}/bin"
@@ -9,6 +10,20 @@ node[:php][:multi][:versions].each do |php_version|
     owner  node.travis_build_environment.user
     group  node.travis_build_environment.group
     mode   "0644"
+  end
+
+  cookbook_file "/etc/profile.d/composer.sh" do
+    owner node.travis_build_environment.user
+    group node.travis_build_environment.group
+    environment Hash["HOME" => composer_path]
+    mode  0755
+  end
+
+  template "#{composer_path}/config.json" do
+    owner  node.travis_build_environment.user
+    group  node.travis_build_environment.group
+    source "config.json.erb"
+    variables(:github_oauth_token => node[:config][:github_oauth_token])
   end
 
   template "#{bin_path}/composer" do

--- a/ci_environment/composer/templates/default/config.json.erb
+++ b/ci_environment/composer/templates/default/config.json.erb
@@ -1,0 +1,7 @@
+{
+    "config": {
+        "github-oauth": {
+            "github.com": "<%= @github_oauth_token %>"
+        }
+    }
+}


### PR DESCRIPTION
This PR setups basic configuration for Composer that allows to easier prevention of reaching GitHub limit by using OAuth token (i.e. simple read-only one). Additionally it disable communcation with external servers to not inform them about downloads (this will reduce time of Composer usage as well it will prevent "bogus" statistics grow at Packagist).
