### PR TITLE
Update sbt-extras to support Scala 2.10.0 by default

### DIFF
--- a/ci_environment/sbt/attributes/default.rb
+++ b/ci_environment/sbt/attributes/default.rb
@@ -8,9 +8,9 @@ else # usual base directory on unix systems:
 end
 override['sbt-extras']['user_home_basedir'] = node['travis_build_environment']['home'].split("/#{node['travis_build_environment']['user']}").first
 
-default['sbt-extras']['download_url']      = 'https://github.com/gildegoma/sbt-extras/raw/139803ca3880c20799bca030b33261c4509dc2d5/sbt'
+default['sbt-extras']['download_url']      = 'https://github.com/gildegoma/sbt-extras/raw/63e8d0f7a6bd25c81f59befc040e6eb3b35e2501/sbt'
 # Refer to this fork, waiting for https://github.com/paulp/sbt-extras/pull/36 to be accepted and merged into master project.
-default['sbt-extras']['default_sbt_version']   = '0.12.1' # ATTENTION: It must match with effective default sbt of installed script.
+default['sbt-extras']['default_sbt_version']   = '0.12.2-RC1' # ATTENTION: It must match with effective default sbt of installed script.
 # Note: ideally, the default sbt version should be 'found' in downloaded script content (see issue #7)
 
 default['sbt-extras']['setup_dir']         = '/opt/sbt-extras'


### PR DESCRIPTION
Scala 2.10.0 has been officially released :cake: and latest version of sbt-extras now refer to it with option `-210` (see paulp/sbt-extras@d074c7bd4520d33494609f73fc132612bf0d5c17)
### Additional Notes:
- This pull request is an update to #107
- I noticed that `sbt-extras` is still not (properly) installed on the JVM worker boxes  (see details history in #107). It will be a great improvement if Travis team could make it live as soon as possible :dancer:! 
- I'll try my best to help, if needed... feel free to ask.

(Sorry for abusing of icons, I just discovered them right now, and I find it so cuuuute :baby: . But let's keep some ASCII in GitHub wonderworld: `<3 <3 <3` to you travis guys!)
