### PR TITLE
Add Sphinx 2.0.4 and make it the default

### DIFF
--- a/ci_environment/sphinx/attributes/default.rb
+++ b/ci_environment/sphinx/attributes/default.rb
@@ -1,7 +1,6 @@
 default[:sphinx] = {
   :versions => {
     '2.0.4-release' => '/usr/local/sphinx-2.0.4',
-    '2.0.1-beta' => '/usr/local/sphinx-2.0.1',
     '1.10-beta'  => '/usr/local/sphinx-1.10',
     '0.9.9'      => '/usr/local/sphinx-0.9.9'
   },

--- a/ci_environment/sphinx/metadata.rb
+++ b/ci_environment/sphinx/metadata.rb
@@ -7,9 +7,8 @@ version           '0.1.1'
 depends           'build-essential'
 
 recipe 'sphinx',               'Installs Sphinx 2.0.4-release'
-recipe 'sphinx::all',          'Installs Sphinx 2.0.4-release, 2.0.1-beta, 1.10-beta and 0.9.9'
+recipe 'sphinx::all',          'Installs Sphinx 2.0.4-release, 1.10-beta and 0.9.9'
 recipe 'sphinx::sphinx-2.0.4', 'Installs Sphinx 2.0.4-release'
-recipe 'sphinx::sphinx-2.0.1', 'Installs Sphinx 2.0.1-beta'
 recipe 'sphinx::sphinx-1.10',  'Installs Sphinx 1.10-beta'
 recipe 'sphinx::sphinx-0.9.9', 'Installs Sphinx 0.9.9'
 


### PR DESCRIPTION
It's the default version on Ubuntu 12.04 and a stable release.
Did not remove 2.0.1-beta as people are probably using it explicitly.
