### PR TITLE
Fixed problem in Cassandra init script

### DIFF
--- a/ci_environment/cassandra/templates/default/cassandra.init.erb
+++ b/ci_environment/cassandra/templates/default/cassandra.init.erb
@@ -105,7 +105,7 @@ classpath()
 # process is not running but the pidfile exists (to match the exit codes for
 # the "status" command; see LSB core spec 3.1, section 20.2)
 #
-CMD_PATT="-user.cassandra.+CassandraDaemon"
+CMD_PATT="cassandra.+CassandraDaemon"
 is_running()
 {
     if [ -f $PIDFILE ]; then
@@ -130,23 +130,9 @@ do_start()
     ulimit -l unlimited
     ulimit -n "$FD_LIMIT"
 
-    cp=`classpath`
-    cassandra_home=`getent passwd cassandra | awk -F ':' '{ print $6; }'`
-    cd /    # jsvc doesn't chdir() for us
+    cd /
 
-    # echo "Classpath is $cp"
-    $JSVC \
-        -user cassandra \
-        -home $JAVA_HOME \
-        -pidfile $PIDFILE \
-        -errfile "&1" \
-        -outfile /var/log/$NAME/output.log \
-        -cp $cp \
-        -Dlog4j.configuration=log4j-server.properties \
-        -XX:HeapDumpPath="$cassandra_home/java_`date +%s`.hprof" \
-        -XX:ErrorFile="$cassandra_home/hs_err_`date +%s`.log" \
-        $JVM_OPTS \
-        org.apache.cassandra.thrift.CassandraDaemon
+    start_daemon -p $PIDFILE $CASSANDRA_HOME/bin/cassandra -p $PIDFILE
 
     is_running && return 0
     for tries in `seq $WAIT_FOR_START`; do
@@ -167,8 +153,9 @@ do_stop()
         #   2 if daemon could not be stopped
         #   other if a failure occurred
     is_running || return 1
-    $JSVC -stop -home $JAVA_HOME -pidfile $PIDFILE \
-            org.apache.cassandra.thrift.CassandraDaemon
+    
+    killproc -p $PID
+    
     is_running && return 2 || return 0
 }
 


### PR DESCRIPTION
Updated the Cassandra init script so that the `cassandra` service starts properly and shuts down cleanly.

I believe this should fix https://github.com/travis-ci/travis-ci/issues/840

The current script repeats most of what's in `/usr/local/cassandra/bin/cassandra`, but not enough, there's a lot of the environment Cassandra needs to start that is missing. This patch changes it so that it simply runs `cassandra -p $PIDFILE` and daemonizes it with `start-stop-daemon` (by way of `start_daemon`). The stop and status tasks had to change too.

The script still contains some hard coded paths and some interpolated, if you pass in another `conf_dir` or even `installation_dir` it will no longer work. I can fix that too if you'd like but I though that just fixing the issue at hand was best to start with. There's also some stuff that could be removed now when `/usr/local/cassandra/bin/cassandra` is doing most of the lifting (the part that finds `JAVA_HOME` for example).
