### PR TITLE
Install ia32-libs package very early on 64-bit OS

### DIFF
--- a/ci_environment/travis_build_environment/recipes/default.rb
+++ b/ci_environment/travis_build_environment/recipes/default.rb
@@ -21,6 +21,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+include_recipe "travis_build_environment::i386"
+
 include_recipe "timezone"
 include_recipe "sysctl"
 

--- a/ci_environment/travis_build_environment/recipes/i386.rb
+++ b/ci_environment/travis_build_environment/recipes/i386.rb
@@ -1,0 +1,6 @@
+# Install support of 32-bit binaries on 64-bit operating system
+
+if node['travis_build_environment']['arch'] == 'amd64'
+  package 'ia32-libs'
+end
+


### PR DESCRIPTION
Support of **ELF 32-bit binaries** is still needed nowadays on a 64-bit multi-purpose server, such as bluebox.

Any travis job that currently fails with error like following is probably depending on a 32-bit binary:

```
Cannot run program "/home/travis/.../.../some-binary-file": error=2, No such file or directory.
```

Example: https://github.com/travis-ci/travis-worker/issues/56

Please: 
- validate that provisioning runs fine with bluebox true base image and chef runlist.
- tell me if it needs more comments/documentation
- you also can try to shift a bit later the installation of this package, if there is any reason to do it (which one?)
