### PR TITLE
Silencing Cassandra output when its starting up

### DIFF
--- a/ci_environment/cassandra/templates/default/cassandra.init.erb
+++ b/ci_environment/cassandra/templates/default/cassandra.init.erb
@@ -130,9 +130,7 @@ do_start()
     ulimit -l unlimited
     ulimit -n "$FD_LIMIT"
 
-    cd /
-
-    start_daemon -p $PIDFILE $CASSANDRA_HOME/bin/cassandra -p $PIDFILE
+    start-stop-daemon --start --quiet --oknodo --chdir / --exec /bin/bash --oknodo --pidfile $PIDFILE -- -c "$CASSANDRA_HOME/bin/cassandra -p $PIDFILE 2>&1 > /dev/null"
 
     is_running && return 0
     for tries in `seq $WAIT_FOR_START`; do


### PR DESCRIPTION
This is a follow up to #134

This fixes an issue where all of Cassandra's logging went to stdout.

The logs are available in /var/log/cassandra/system.log so what's written to stdout is not necessary to redirect anywhere else.
