### PR TITLE
Cassandra init script fix (now starting as the right user)

### DIFF
--- a/ci_environment/cassandra/templates/default/cassandra.init.erb
+++ b/ci_environment/cassandra/templates/default/cassandra.init.erb
@@ -43,7 +43,7 @@ FD_LIMIT=100000
 #   1 if daemon is not running
 is_running()
 {
-    start-stop-daemon --status --pidfile $PIDFILE --user $USER && return 0
+    [ -f $PIDFILE -a -d /proc/$(cat $PIDFILE) ] && return 0
     return 1
 }
 


### PR DESCRIPTION
Hi guys, I'm really sorry that I missed that the cassandra service didn't start as the right user in my last PR. I hope this one will be the last patch needed. @michaelklishin pointed me to sous-chef which made it so much easier to get it right.

This patch makes sure Cassandra starts as the cassandra user, it fixes some hard coded paths in the init script, and I've made sure it uses `start-stop-daemon` to start and stop. I've also cleared out all the old setup code that is no longer needed (JAVA_HOME and the classpath is detected by Cassandra itself).
