### PR TITLE
Install libffi for ruby

### DIFF
--- a/ci_environment/rvm/recipes/default.rb
+++ b/ci_environment/rvm/recipes/default.rb
@@ -34,6 +34,7 @@ include_recipe "libreadline"
 include_recipe "libxml"
 include_recipe "libssl"
 include_recipe "libncurses"
+include_recipe "libffi"
 
 bash "install RVM" do
   user        node.travis_build_environment.user


### PR DESCRIPTION
This ensures that the "fiddle" stdlib gets built.

---

Note that I have been unable to test that this does actually have the desired effect. Let me know if you're happy to just merge it, or if you'd like me to try harder to build a test VM and test it properly.
