### PR TITLE
Updated Gradle version from 1.3 to 1.4.

### DIFF
--- a/ci_environment/gradle/attributes/tarball.rb
+++ b/ci_environment/gradle/attributes/tarball.rb
@@ -1,4 +1,4 @@
-gradle_version = "1.3"
+gradle_version = "1.4"
 
 default[:gradle] = {
   :version          => gradle_version,


### PR DESCRIPTION
Gradle 1.4 was released a few days ago. It has a few minor enhancements that I am taking advantage of that cause my build to fail on 1.3. Specifically, the automatic configuration of Scala dependency used by ScalaCompile and Scaladoc tasks: http://www.gradle.org/docs/current/release-notes#automatic-configuration-of-scala-dependency-used-by-scalacompile-and-scaladoc-tasks
