### PR TITLE
sbt javaopts flags

### DIFF
--- a/ci_environment/sbt/templates/default/jvmopts.erb
+++ b/ci_environment/sbt/templates/default/jvmopts.erb
@@ -1,7 +1,7 @@
--XX:ReservedCodeCacheSize=96M
--Xms1024M
--Xmx1536M
+-XX:ReservedCodeCacheSize=256M
+-Xms2048M
+-Xmx2048M
 -Xss6M
 -XX:+CMSClassUnloadingEnabled
 -XX:+UseConcMarkSweepGC
--XX:MaxPermSize=384M
+-XX:MaxPermSize=512M


### PR DESCRIPTION
OpenJDK 6 and 7 by default have UseConcMarkSweepGC disabled. Thus, setting just CMSClassUnloadingEnabled will not work as intended. This can be verified by examining the OpenJDK 6 and 7 source. /hotspot/src/share/vm/runtime/globals.hpp declares it as false by default and the only GC where it is used is /hotspot/src/share/vm/gc_implementation/concurrentMarkSweep/concurrentMarkSweepGeneration.cpp.

Note: It is possible for the CMS GC to be automatically selected, as defined in arguments.cpp. However, explicitly stating it would assure its use.

Also updated sbt java opts to take advantage of bluebox memory. These can be overridden.
