### PR TITLE
Enable MongoDB auth by default

### DIFF
--- a/ci_environment/mongodb/attributes/mongodb.rb
+++ b/ci_environment/mongodb/attributes/mongodb.rb
@@ -17,7 +17,7 @@ default[:mongodb][:bind_ip] = '127.0.0.1'
 
 ### EXTRA
 default[:mongodb][:log_cpu_io]  = false
-default[:mongodb][:auth]        = false
+default[:mongodb][:auth]        = true
 default[:mongodb][:username]    = ""
 default[:mongodb][:password]    = ""
 default[:mongodb][:verbose]     = false

--- a/ci_environment/mongodb/templates/default/mongodb.conf.erb
+++ b/ci_environment/mongodb/templates/default/mongodb.conf.erb
@@ -3,3 +3,4 @@
 
 dbpath=<%= node[:mongodb][:datadir] %>
 bind_ip=<%= node[:mongodb][:bind_ip] %>
+auth=<%= node[:mongodb][:auth] %>


### PR DESCRIPTION
This only affects connections from remote hosts. Connections from localhost are not required to authenticate.

According to @TylerBrock, it should be safe to enable this by default as it allows to test authentication, but doesn't require any changes to projects and apps that are currently running without authentication.
