### PR TITLE
Perl 5.8 image

### DIFF
--- a/ci_environment/perlbrew/attributes/multi.rb
+++ b/ci_environment/perlbrew/attributes/multi.rb
@@ -5,6 +5,7 @@ default[:perlbrew] = {
                { :name => "5.16", :version => "perl-5.16.3" },
                { :name => "5.14", :version => "perl-5.14.4" },
                { :name => "5.12", :version => "perl-5.12.5" },
-               { :name => "5.10", :version => "perl-5.10.1" }],
+               { :name => "5.10", :version => "perl-5.10.1" },
+               { :name => "5.8",  :version => "perl-5.8.9"  }],
   :modules => %w(Dist::Zilla Moose Test::Pod Test::Pod::Coverage Test::Exception Test::Kwalitee Dist::Zilla::Plugin::Bootstrap::lib LWP Module::Install Test::Most)
 }


### PR DESCRIPTION
redirected from https://github.com/travis-ci/travis-build/issues/99

Granted perl 5.8 is not supported officially, but that's the same with 5.10/12 anyway, and 5.8 is still reasonably well being used at the production and majority of the CPAN module authors still support it.

It's great if we can test to see if a module builds properly using Travis + 5.8.
