### PR TITLE
Add 5.19.0, bump 5.1[246].x to latest releases, add aliases for latest s...

### DIFF
--- a/ci_environment/perlbrew/attributes/multi.rb
+++ b/ci_environment/perlbrew/attributes/multi.rb
@@ -1,9 +1,12 @@
 default[:perlbrew] = {
-  :perls   => [{ :name => "5.18", :version => "perl-5.18.0" },
+  :perls   => [
+               { :name => "dev", :version => "perl-5.19.0" },
+               { :name => "stable", :version => "perl-5.18.0" },
+               { :name => "5.18", :version => "perl-5.18.0" },
                { :name => "5.17", :version => "perl-5.17.7" },
-               { :name => "5.16", :version => "perl-5.16.2" },
-               { :name => "5.14", :version => "perl-5.14.2" },
-               { :name => "5.12", :version => "perl-5.12.4" },
+               { :name => "5.16", :version => "perl-5.16.3" },
+               { :name => "5.14", :version => "perl-5.14.4" },
+               { :name => "5.12", :version => "perl-5.12.5" },
                { :name => "5.10", :version => "perl-5.10.1" }],
   :modules => %w(Dist::Zilla Moose Test::Pod Test::Pod::Coverage Test::Exception Test::Kwalitee Dist::Zilla::Plugin::Bootstrap::lib LWP Module::Install Test::Most)
 }


### PR DESCRIPTION
...table and dev releases

There are newer versions in each of 5.16.x, 5.14.x and 5.12.x.

The 5.17.x line is now irrelevant, now that 5.18.0 is released -- new bleeding edge development is now available in 5.19.x -- but removing its entry would break everyone's builds that are referencing it, so I'll leave it to you guys to decide whether to remove it.

Aliases to the latest development and stable release would be very helpful in the future to avoid lots of little updates to config files -- people can simply say 'dev' and be assured that it will point to the latest development release, without having to make updates from 5.17->5.19 etc.
