### PR TITLE
Node.js: handle multi-versions without repetition

### DIFF
--- a/ci_environment/nodejs/attributes/multi.rb
+++ b/ci_environment/nodejs/attributes/multi.rb
@@ -1,3 +1,13 @@
-default[:nodejs][:default]  = "0.10.12"
-default[:nodejs][:versions] = [ node[:nodejs][:default] ]
-default[:nodejs][:aliases]  = { node[:nodejs][:default] => node[:nodejs][:default][/\d+\.\d+/] }
+default[:nodejs][:default]  = '0.10.12'
+default[:nodejs][:others]   = nil
+
+if node[:nodejs][:others].is_a?(Array)
+  default[:nodejs][:versions] = node[:nodejs][:others].insert(0, node[:nodejs][:default]).uniq
+else
+  default[:nodejs][:versions] = [ node[:nodejs][:default] ]
+end
+
+node[:nodejs][:versions].each do |nv| 
+  default[:nodejs][:aliases][nv] = nv[/\d+\.\d+/]
+end
+


### PR DESCRIPTION
In continuation to #195, this change aims to simplify travis-boxes overrides for the Node.js
worker (corresponding PR is coming asap)
