### PR TITLE
Upgrade PostgreSQL to v9.2

### DIFF
--- a/ci_environment/postgresql/attributes/default.rb
+++ b/ci_environment/postgresql/attributes/default.rb
@@ -30,7 +30,7 @@ when "ubuntu"
   default[:postgresql][:version] = if platform_version.to_f <= 9.04
                                      "8.3"
                                    elsif platform_version.to_f >= 11.10
-                                     "9.1"
+                                     "9.2"
                                    else
                                      "8.4"
                                    end


### PR DESCRIPTION
There seem to be an increasing number of posts about how to upgrade Postgres via Travis before scripts. Heroku Postgres.app has moved to 9.2 as well, making it an increasingly common target. It's understood that if this were accepted it would have to wait for the next VM update.
