### PR TITLE
support ghc-7.6.3 and haskell-platform-2013.2.0.0

### DIFF
--- a/ci_environment/haskell/recipes/default.rb
+++ b/ci_environment/haskell/recipes/default.rb
@@ -27,7 +27,7 @@ cookbook_file "/etc/profile.d/cabal.sh" do
   mode 0755
 end
 
-if node.ghc.version == "7.6.3" and node.haskell.platform == "2013.2.0.0" then
+if node.ghc.version.to_s.to_f >= 7.6 and node.haskell.platform.to_s.to_f >= 2013.2 then
   include_recipe "haskell::ghc_source"
   include_recipe "haskell::platform_source"
 else


### PR DESCRIPTION
As a travis user I wanna use ghc-7.6.3 and haskell-platform-2013.2.0.0 in haskell builds. All necessary infrastructure is already done, so here is some silly-looking changes that makes it possible to use new ghc if specific attributes is set.

I've tested it in `sous-chef` with runlist (part of `Vagrantfile`)

```
    chef.add_recipe     "build-essential"
    chef.add_recipe     "networking_basic"

    chef.add_recipe     "travis_build_environment"
    chef.add_recipe     "git"
    chef.add_recipe     "haskell::default"

    chef.add_recipe     "java::openjdk7"
```

and attributes:

``` ruby
     chef.json.merge!({
      :ghc => {
        :version => "7.6.3",
      },
      :haskell => {
        :platform => {
          :version => "2013.2.0.0"
        }
      }
    })
```

Any ideas how to improve that?
