### PR TITLE
Initial Sauce Labs worker support

### DIFF
--- a/worker_host/travis_worker/recipes/saucelabs.rb
+++ b/worker_host/travis_worker/recipes/saucelabs.rb
@@ -1,0 +1,98 @@
+include_recipe "runit"
+include_recipe "jruby"
+
+users = if Chef::Config[:solo]
+          node[:users]
+        else
+          search(:users)
+        end
+
+execute "monit-reload" do
+  action :nothing
+  command "monit reload"
+end
+
+package "ruby1.9.3" do
+  action :install
+end
+
+cookbook_file "/usr/local/bin/signal_wrapper" do
+  source "signal_wrapper.rb"
+  mode "0755"
+  owner "root"
+  backup false
+end
+
+1.upto(node[:travis][:worker][:workers]) do |worker|
+  app = "worker-#{worker}"
+  worker_name = "#{app}.#{node[:fqdn]}"
+  home = "#{node[:travis][:worker][:home]}/#{app}"
+  service_name = "travis-worker-#{worker}"
+  host_name = "#{node[:travis][:worker][:hostname]}-#{worker}.#{node[:travis][:worker][:domain]}"
+
+  service service_name do
+    action :nothing
+  end
+
+  directory home do
+    action :create
+    recursive true
+    owner "travis"
+    group "travis"
+    mode "0755"
+  end
+
+  git home do
+    repository node[:travis][:worker][:repository]
+    reference node[:travis][:worker][:ref]
+    action :sync
+    user "travis"
+    group "travis"
+    notifies :restart, resources(:service => service_name)
+  end
+
+  directory "#{home}/log" do
+    action :create
+    owner "travis"
+    group "travis"
+    mode "0755"
+  end
+
+  bash "bundle gems" do
+    code "#{File.dirname(node[:jruby][:bin])}/bundle install --deployment --binstubs"
+    user "travis"
+    group "travis"
+    cwd home
+  end
+
+  template "#{home}/config/worker.yml" do
+    source "worker-saucelabs.yml.erb"
+    owner "travis"
+    group "travis"
+    mode "0600"
+    variables :amqp => node[:travis][:worker][:amqp],
+              :worker => node[:travis][:worker],
+              :hostname => host_name,
+              :saucelabs => node[:saucelabs],
+              :librato => node[:collectd_librato],
+
+    notifies :restart, resources(:service => service_name)
+  end
+
+  runit_service "travis-worker-#{worker}" do
+    options :jruby => node[:jruby][:bin],
+            :worker_home => home,
+            :user => "travis",
+            :group => "travis",
+    template_name "travis_worker"
+  end
+
+  template "/etc/monit/conf.d/travis-worker-#{worker}.monitrc" do
+    source "travis-worker-saucelabs.monitrc.erb"
+    owner "root"
+    group "root"
+    mode "0644"
+    variables :service_name => service_name
+    notifies :run, resources(:execute => "monit-reload")
+  end
+end

--- a/worker_host/travis_worker/templates/default/travis-worker-saucelabs.monitrc.erb
+++ b/worker_host/travis_worker/templates/default/travis-worker-saucelabs.monitrc.erb
@@ -1,0 +1,8 @@
+check process <%= @service_name %>
+  with pidfile /etc/sv/<%= @service_name %>/supervise/pid
+  group travis-worker
+  if changed pid then alert
+  if totalcpu > 3% for 5 cycles then alert
+  if totalcpu > 3% for 10 cycles then restart
+  stop program "/usr/bin/sv stop <%= @service_name %>"
+  start program "/usr/bin/sv start <%= @service_name %>"

--- a/worker_host/travis_worker/templates/default/worker-saucelabs.yml.erb
+++ b/worker_host/travis_worker/templates/default/worker-saucelabs.yml.erb
@@ -1,0 +1,30 @@
+env: <%= @worker[:env] %>
+mac_osx:
+<% if @worker[:logging_channel] -%>
+  logging_channel: <%= @worker[:logging_channel] %>
+<% end -%>
+  host: <%= @hostname %>
+  log_level: <%= @worker[:log_level] %>
+  amqp:
+  <% @amqp.each do |key, value| -%>
+    <%= key %>: <%= value %>
+  <% end -%>
+  vms:
+    provider: <%= @worker[:provider] %>
+    count: <%= @worker[:vms] %>
+  sauce_labs:
+    api_endpoint: <%= @saucelabs[:api_endpoint] %>
+    private_key_passphrase: <%= @saucelabs[:private_key_passphrase] %>
+    private_key_path: <%= @saucelabs[:private_key_path] %>
+  librato:
+    email: <%= @librato[:email] %>
+    token: <%= @librato[:api_token] %>
+<% if @worker[:timeouts] -%>
+  timeouts:
+  <% @worker[:timeouts].each do |timeout, value| -%>
+    <%= timeout -%>: <%= value %>
+  <% end -%>
+<% end -%>
+<% if @worker[:shutdown_timeout] -%>
+  shutdown_timeout: <%= @worker[:shutdown_timeout] %>
+<% end -%>


### PR DESCRIPTION
Some initial work on recipes for moving the Sauce Labs workers to their own machines.

There's a lot of duplication between this recipe and the bluebox recipe. Maybe extract all that into a "parent" recipe? May be a good use for the current `default` recipe if we don't plan to use that anymore?
