### PR TITLE
Add 'gcc' cookbook to install gcc 4.8 on ubuntu 12.04LTS

### DIFF
--- a/ci_environment/gcc/attributes/ppa.rb
+++ b/ci_environment/gcc/attributes/ppa.rb
@@ -1,0 +1,3 @@
+default['gcc']['ppa']['version']    = '4.8'
+default['gcc']['ppa']['as_default'] = true
+

--- a/ci_environment/gcc/metadata.rb
+++ b/ci_environment/gcc/metadata.rb
@@ -1,0 +1,13 @@
+name             'gcc'
+maintainer       'Travis CI Development Team'
+license          'Apache v2.0'
+description      'Installs/Configures gcc/g++'
+version          '0.1.0'
+
+supports         'ubuntu'
+
+depends          'apt'
+
+recipe           'gcc::default',       'Installs default gcc version from platform official package repository'
+recipe           'gcc::ppa',           'Installs gcc from ubuntu-toolchain-r/test PPA'
+

--- a/ci_environment/gcc/recipes/default.rb
+++ b/ci_environment/gcc/recipes/default.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: gcc
+# Recipe:: default
+#
+# Copyright 2013, Travis CI Development Team <contact@travis-ci.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_recipe 'gcc::dependencies'
+
+package 'gcc'
+

--- a/ci_environment/gcc/recipes/dependencies.rb
+++ b/ci_environment/gcc/recipes/dependencies.rb
@@ -1,0 +1,5 @@
+
+%w(libtool).each do |p|
+  package p
+end
+

--- a/ci_environment/gcc/recipes/ppa.rb
+++ b/ci_environment/gcc/recipes/ppa.rb
@@ -1,0 +1,48 @@
+#
+# Cookbook Name:: gcc
+# Recipe:: ppa
+#
+# Copyright 2013, Travis CI Development Team <contact@travis-ci.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This recipe relies on a PPA package and is Ubuntu/Debian specific. Please
+# keep this in mind.
+
+
+apt_repository "ubuntu-toolchain-r-test" do
+  uri          "http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu"
+  distribution node['lsb']['codename']
+  components   ["main"]
+  key          "BA9EF27F"
+  keyserver    "keyserver.ubuntu.com"
+  action       :add
+end
+
+include_recipe 'gcc::dependencies'
+package "g++-#{node['gcc']['ppa']['version']}"
+
+%w(gcc g++).each do |alt_name|
+  execute "Remove all previous #{alt_name} alternatives" do
+    command "update-alternatives --remove-all #{alt_name}"
+    returns [0, 2] # error code 2 is returned if no alternative has been configured so far.
+  end
+  execute "Install gcc #{node['gcc']['ppa']['version']} as default alternative" do
+    command "update-alternatives --install /usr/bin/#{alt_name} #{alt_name} /usr/bin/#{alt_name}-#{node['gcc']['ppa']['version']} 20"
+  end
+  execute "Double check that there is only one alternative installed for #{alt_name}" do
+    command "update-alternatives --config #{alt_name}"
+  end
+end if node['gcc']['ppa']['as_default']
+


### PR DESCRIPTION
This cookbook currently provides two recipes:
- `default.rb`, to install ubuntu 'gcc' default package
- `ppa.rb`, to install latest 'gcc' from ubuntu-toolchain-r/test PPA

Address travis-ci/travis-ci#1379
Related to travis-ci/travis-ci#979

With attribute `as_default = true`, recipe `ppa` can install gcc 4.8 as default gcc compiler, which is good if we don't want to modify `travis-build` C/C++ builders (each time we update gcc). That said, I'm not sure if making gcc 4.8 default is 100% safe (won't it break anything on ubuntu 12.04?). An conservative option could be to create a specific VM image for C/C++ with gcc 4.8, but keep standard gcc package on other language VMs. @o11c @bendiken @mavam @maksbotan any thoughts on this point?
