### PR TITLE
[php] include bison and libreadline tricky recipes

### DIFF
--- a/ci_environment/libreadline/recipes/default.rb
+++ b/ci_environment/libreadline/recipes/default.rb
@@ -27,7 +27,7 @@ when "debian","ubuntu"
   when "11.04" then
     package "libreadline5-dev"
     package "libreadline5"
-  when "11.10" then
+  else  
     package "libreadline-dev"
     package "libreadline6"
   end

--- a/ci_environment/php/metadata.rb
+++ b/ci_environment/php/metadata.rb
@@ -7,6 +7,11 @@ version           "1.0.0"
 
 depends "apt"
 depends "build-essential"
+
+depends "bison"           # required to ensure that bison version is compatible with annoying php whitelist 
+                          # (This trick is required up to PHP 5.5.3, see https://github.com/php/php-src/pull/402)
+depends "libreadline"     # required to build PHP from C/C++ source
+
 depends "composer"
 depends "phpbuild"
 depends "phpenv"

--- a/ci_environment/php/recipes/multi.rb
+++ b/ci_environment/php/recipes/multi.rb
@@ -1,3 +1,6 @@
+include_recipe "bison"
+include_recipe "libreadline"
+
 include_recipe "phpenv"
 include_recipe "phpbuild"
 


### PR DESCRIPTION
This change aims to solve following errors (if `bison` and `libreadline` are not explicitely set in the chef run_list):

```
[Info]: Building 5.3.3 into /home/vagrant/.phpenv/versions/5.3.3
       [Downloading]: http://museum.php.net/php5/php-5.3.3.tar.bz2
       [Preparing]: /tmp/php-build/source/5.3.3

       -----------------
       |  BUILD ERROR  |
       -----------------

       Here are the last 10 lines from the log:

       -----------------------------------------
       configure: warning: bison versions supported for regeneration of the Zend/PHP parsers: 1.28 1.35 1.75 1.875 2.0 2.1 2.2 2.3 2.4 2.4.1 2.4.2 (found: 2.5).
       configure: error: Please reinstall readline - I cannot find readline.h

```

@loicfrering @michaelklishin could you please review this ? Actually, I would propose to refactor even more and directly bundle `bison` and `libreadline` tricks into `php` cookbook... what do you think?

@joshk while being bitten by this problem, I noticed following [travis-images bootstrap step](https://github.com/travis-ci/travis-images/blob/master/lib/travis/cloud_images/vm_provisioner.rb#L25). Shouldn't we shift the installation of these apt packages to travis-cookbooks ?
