### PR TITLE
Upgrade elasticsearch to v0.90.5

### DIFF
--- a/ci_environment/elasticsearch/attributes/default.rb
+++ b/ci_environment/elasticsearch/attributes/default.rb
@@ -1,5 +1,5 @@
 default[:elasticsearch] = {
-  :version => "0.90.1",
+  :version => "0.90.5",
   :service => {
     :enabled => false
   }


### PR DESCRIPTION
Version 0.90.5 of elasticsearch is the latest stable version
