### PR TITLE
Add the latest Erlang release to ci-environment

### DIFF
--- a/ci_environment/kerl/attributes/source.rb
+++ b/ci_environment/kerl/attributes/source.rb
@@ -1,2 +1,2 @@
-default[:kerl][:releases] = %w(R14B02 R14B03 R14B04 R15B R15B01 R15B02 R15B03 R16B01)
+default[:kerl][:releases] = %w(R14B02 R14B03 R14B04 R15B R15B01 R15B02 R15B03 R16B01 R16B02)
 default[:kerl][:path]     = "/usr/local/bin/kerl"


### PR DESCRIPTION
The latest, and greatest, Erlang release is now R16B02.
It is also supported by Kerl, but your CI environment
doesn't yet reflect it's release.

This commit adds R16B02 to the list of releases
installed with Kerl.

The documentation for the Erlang setup on Travis-CI
should potentially also be updated to reflect the change.
