### PR TITLE
add encodings to metadata files that use non-ascii chars

### DIFF
--- a/ci_environment/mongodb/metadata.rb
+++ b/ci_environment/mongodb/metadata.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 name              "mongodb"
 maintainer        "Michael Strüder"
 maintainer_email  "mikezter@gmail.com"

--- a/ci_environment/php/metadata.rb
+++ b/ci_environment/php/metadata.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 name              "php"
 maintainer        "Loïc Frering"
 maintainer_email  "loic.frering@gmail.com"
@@ -8,7 +10,7 @@ version           "1.0.0"
 depends "apt"
 depends "build-essential"
 
-depends "bison"           # required to ensure that bison version is compatible with annoying php whitelist 
+depends "bison"           # required to ensure that bison version is compatible with annoying php whitelist
                           # (This trick is required up to PHP 5.5.3, see https://github.com/php/php-src/pull/402)
 depends "libreadline"     # required to build PHP from C/C++ source
 

--- a/ci_environment/phpbuild/metadata.rb
+++ b/ci_environment/phpbuild/metadata.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 name              "phpbuild"
 maintainer        "Loïc Frering"
 maintainer_email  "loic.frering@gmail.com"

--- a/ci_environment/phpenv/metadata.rb
+++ b/ci_environment/phpenv/metadata.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 name              "phpenv"
 maintainer        "Loïc Frering"
 maintainer_email  "loic.frering@gmail.com"


### PR DESCRIPTION
Running chef on 1.9 yields syntax errors like `travis-cookbooks/ci_environment/php/metadata.rb:2: invalid multibyte char (US-ASCII)`

These changes should fix that.
