### PR TITLE
Add `-Duseshrplib` flag for `perlbrew`

### DIFF
--- a/ci_environment/perlbrew/attributes/multi.rb
+++ b/ci_environment/perlbrew/attributes/multi.rb
@@ -1,7 +1,9 @@
 default[:perlbrew] = {
   :perls   => [{ :name => "5.21", :version => "perl-5.21.0" },
                { :name => "5.20", :version => "perl-5.20.0"  },
+               { :name => "5.20-shrplib", :version => "perl-5.20.0", :arguments => "-Duseshrplib" },
                { :name => "5.18", :version => "perl-5.18.2" },
+               { :name => "5.18-shrplib", :version => "perl-5.18.2", :arguments => "-Duseshrplib" },
                { :name => "5.16", :version => "perl-5.16.3" },
                { :name => "5.14", :version => "perl-5.14.4" },
                { :name => "5.12", :version => "perl-5.12.5" },

--- a/ci_environment/perlbrew/recipes/multi.rb
+++ b/ci_environment/perlbrew/recipes/multi.rb
@@ -22,7 +22,7 @@ node.perlbrew.perls.each do |pl|
 
   bash "installing #{pl[:version]} as #{pl[:name]} with Perlbrew arguments: #{args}" do
     setup.call(self)
-    code   "#{brew} install #{pl[:version]} --as #{pl[:name]} #{args} -Duseshrplib"
+    code   "#{brew} install #{pl[:version]} --as #{pl[:name]} #{args}"
     not_if "ls #{home}/perl5/perlbrew/perls | grep #{pl[:name]}"
   end
 


### PR DESCRIPTION
See travis-ci/travis-ci#1752

This would result in something like:

```
$ ./perl -V
Summary of my perl5 (revision 5 version 19 subversion 6) configuration:

  Platform:
    osname=linux, osvers=3.2.0-23-generic, archname=x86_64-linux
    uname='linux precise64 3.2.0-23-generic #36-ubuntu smp tue apr 10 20:39:51 utc 2012 x86_64 x86_64 x86_64 gnulinux '
    config_args='-de -Dprefix=/home/travis/perl5/perlbrew/perls/5.19 -Duseshrplib -Dusedevel -Aeval:scriptdir=/home/travis/perl5/perlbrew/perls/5.19/bin'
    hint=recommended, useposix=true, d_sigaction=define
    useithreads=undef, usemultiplicity=undef
    useperlio=define, d_sfio=undef, uselargefiles=define, usesocks=undef
    use64bitint=define, use64bitall=define, uselongdouble=undef
    usemymalloc=n, bincompat5005=undef
  Compiler:
    cc='cc', ccflags ='-fno-strict-aliasing -pipe -fstack-protector -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64',
    optimize='-O2',
    cppflags='-fno-strict-aliasing -pipe -fstack-protector -I/usr/local/include'
    ccversion='', gccversion='4.6.3', gccosandvers=''
    intsize=4, longsize=8, ptrsize=8, doublesize=8, byteorder=12345678
    d_longlong=define, longlongsize=8, d_longdbl=define, longdblsize=16
    ivtype='long', ivsize=8, nvtype='double', nvsize=8, Off_t='off_t', lseeksize=8
    alignbytes=8, prototype=define
  Linker and Libraries:
    ld='cc', ldflags =' -fstack-protector -L/usr/local/lib'
    libpth=/usr/local/lib /lib/x86_64-linux-gnu /lib/../lib /usr/lib/x86_64-linux-gnu /usr/lib/../lib /lib /usr/lib
    libs=-lnsl -ldl -lm -lcrypt -lutil -lc
    perllibs=-lnsl -ldl -lm -lcrypt -lutil -lc
    libc=, so=so, useshrplib=true, libperl=libperl.so
    gnulibc_version='2.15'
  Dynamic Linking:
    dlsrc=dl_dlopen.xs, dlext=so, d_dlsymun=undef, ccdlflags='-Wl,-E -Wl,-rpath,/home/travis/perl5/perlbrew/perls/5.19/lib/5.19.6/x86_64-linux/CORE'
    cccdlflags='-fPIC', lddlflags='-shared -O2 -L/usr/local/lib -fstack-protector'


Characteristics of this binary (from libperl):
  Compile-time options: HAS_TIMES PERLIO_LAYERS PERL_DONT_CREATE_GVSV
                        PERL_HASH_FUNC_ONE_AT_A_TIME_HARD PERL_MALLOC_WRAP
                        PERL_NEW_COPY_ON_WRITE PERL_PRESERVE_IVUV
                        PERL_USE_DEVEL USE_64_BIT_ALL USE_64_BIT_INT
                        USE_LARGE_FILES USE_LOCALE USE_LOCALE_COLLATE
                        USE_LOCALE_CTYPE USE_LOCALE_NUMERIC USE_PERLIO
                        USE_PERL_ATOF
  Built under linux
  Compiled at Dec 17 2013 14:16:57
  @INC:
    /home/travis/perl5/perlbrew/perls/5.19/lib/site_perl/5.19.6/x86_64-linux
    /home/travis/perl5/perlbrew/perls/5.19/lib/site_perl/5.19.6
    /home/travis/perl5/perlbrew/perls/5.19/lib/5.19.6/x86_64-linux
    /home/travis/perl5/perlbrew/perls/5.19/lib/5.19.6
    .
```
