### PR TITLE
Add CONTINUOUS_INTEGRATION ENV variable as an alias for CI and TRAVIS ENV variables.

### DIFF
--- a/ci_environment/travis_build_environment/templates/default/etc/environment.sh.erb
+++ b/ci_environment/travis_build_environment/templates/default/etc/environment.sh.erb
@@ -5,6 +5,7 @@ DEBIAN_FRONTEND=noninteractive
 
 TRAVIS=true
 CI=true
+CONTINUOUS_INTEGRATION=true 
 
 LC_CTYPE=en_US.UTF-8
 LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Requested by @jfelchner in https://github.com/travis-ci/travis-ci/issues/1337#issuecomment-22991438.
