### PR TITLE
Cleanup cruft that accumulates during provisioning

### DIFF
--- a/ci_environment/java/recipes/oraclejdk7.rb
+++ b/ci_environment/java/recipes/oraclejdk7.rb
@@ -35,6 +35,6 @@ if node.java.oraclejdk7.install_jce_unlimited
 end
 
 directory '/var/cache/oracle-jdk7-installer' do
-  action :remove
+  action :delete
   ignore_failure true
 end

--- a/ci_environment/java/recipes/oraclejdk8.rb
+++ b/ci_environment/java/recipes/oraclejdk8.rb
@@ -32,7 +32,7 @@ link "#{oraclejdk8_home}/jre/lib/security/cacerts" do
 end
 
 directory '/var/cache/oracle-jdk8-installer' do
-  action :remove
+  action :delete
   ignore_failure true
 end
 


### PR DESCRIPTION
We install a lot of stuff, and some of it leaves things around that just waste space, but have no use whatsoever, increasing the size of the build image without any benefit.

This is WIP and attempts to remove what's not required by default.
