### PR TITLE
update URL for downloading rebar binary

### DIFF
--- a/ci_environment/rebar/attributes/default.rb
+++ b/ci_environment/rebar/attributes/default.rb
@@ -1,2 +1,2 @@
 default[:rebar][:path]     = "/usr/local/bin/rebar"
-default[:rebar][:release]  = "https://github.com/downloads/basho/rebar/rebar"
+default[:rebar][:release]  = "https://github.com/rebar/rebar/wiki/rebar"


### PR DESCRIPTION
Updates the URL to download the rebar binary from the canonical rebar repo. Should resolve travis-ci/travis-ci#2024.
