### PR TITLE
PHPUnit Updates

### DIFF
--- a/ci_environment/phpbuild/files/default/after-install.d/phpunit.sh
+++ b/ci_environment/phpbuild/files/default/after-install.d/phpunit.sh
@@ -17,10 +17,23 @@ use_pear() {
     "$pear" channel-discover pear.phpunit.de
 
     if "$PREFIX/bin/php" -v | grep "PHP 5.2"; then
+        "$pear" install "symfony/YAML-1.0.2"
         "$pear" install "phpunit/File_Iterator-1.3.2"
         "$pear" install "phpunit/Text_Template-1.1.2"
         "$pear" install "phpunit/PHP_Timer-1.0.3"
+        "$pear" install "phpunit/PHP_TokenStream-1.1.4"
+        "$pear" install "phpunit/PHP_CodeCoverage-1.1.4"
+        "$pear" install "phpunit/PHPUnit_MockObject-1.1.1"
         "$pear" install "phpunit/PHPUnit-3.6.12"
+    elif "$PREFIX/bin/php" -v | grep "PHP 5.3"; then
+        "$pear" install "symfony/Yaml-2.3.11"
+        "$pear" install "phpunit/File_Iterator-1.3.4"
+        "$pear" install "phpunit/Text_Template-1.2.0"
+        "$pear" install "phpunit/PHP_Timer-1.0.5"
+        "$pear" install "phpunit/PHP_TokenStream-1.2.2"
+        "$pear" install "phpunit/PHP_CodeCoverage-1.2.16"
+        "$pear" install "phpunit/PHPUnit_MockObject-1.2.3"
+        "$pear" install "phpunit/PHPUnit-3.7.32"
     else
         "$pear" install "phpunit/PHPUnit"
     fi


### PR DESCRIPTION
I think it would be a good idea to lock php 5.3 on the 3.7 LTS version of phpunit like you did with php 5.2 and phpunit 3.6, and allow php 5.4+ to continue with the new php 4.x.
