### PR TITLE
Updated cookies used to download UnlimitedJCEPolicyJDK7 from Oracle

### DIFF
--- a/ci_environment/java/recipes/oraclejdk7.rb
+++ b/ci_environment/java/recipes/oraclejdk7.rb
@@ -31,7 +31,7 @@ link "#{oraclejdk7_home}/jre/lib/security/cacerts" do
 end
 
 if node.java.oraclejdk7.install_jce_unlimited
-  execute "curl -L --cookie 'ARU_LANG=US; s_cc=true; gpw_e24=http%3A%2F%2Fwww.oracle.com%2Ftechnetwork%2Fjava%2Fjavase%2Fdownloads%2Fjce-6-download-429243.html; s_sq=oracleotnlive%2Coracleglobal%3D%2526pid%253Dotn%25253Aen-us%25253A%25252Fjava%25252Fjavase%25252Fdownloads%25252Fjce-6-download-429243.html%2526pidt%253D1%2526oid%253Dhttp%25253A%25252F%25252Fwww.oracle.com%25252Ftechnetwork%25252Fjava%25252Fjavase%25252Fdownloads%25252Fjce-6-download-429243.html%2526ot%253DA'  http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip -o /tmp/policy.zip && sudo unzip -j -o /tmp/policy.zip *.jar -d #{oraclejdk7_home}/jre/lib/security && rm /tmp/policy.zip"
+  execute "curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip -o /tmp/policy.zip && sudo unzip -j -o /tmp/policy.zip *.jar -d #{oraclejdk7_home}/jre/lib/security && rm /tmp/policy.zip"
 end
 
 directory '/var/cache/oracle-jdk7-installer' do


### PR DESCRIPTION
Only the `oraclelicense=accept-securebackup-cookie` cookie should be required.
