### PR TITLE
nvm.sh: Replace exit for return

### DIFF
--- a/ci_environment/nodejs/files/default/nvm.sh
+++ b/ci_environment/nodejs/files/default/nvm.sh
@@ -26,7 +26,7 @@ if [ ! `which curl` ]; then
         }
     else
         echo 'Need curl or wget to proceed. Terminating.'
-        exit 1
+        return 1
     fi
 fi
 


### PR DESCRIPTION
Exiting from a sourced script causes the shell to exit. Returning will result in the desired behaviour.
