### PR TITLE
Support Erlang 17.0 with kerl

### DIFF
--- a/ci_environment/kerl/attributes/source.rb
+++ b/ci_environment/kerl/attributes/source.rb
@@ -1,2 +1,2 @@
-default[:kerl][:releases] = %w(R14B02 R14B03 R14B04 R15B R15B01 R15B02 R15B03 R16B R16B01 R16B02 R16B03 R16B03-1 17.0-rc1 17.0-rc2)
+default[:kerl][:releases] = %w(R14B02 R14B03 R14B04 R15B R15B01 R15B02 R15B03 R16B R16B01 R16B02 R16B03 R16B03-1 17.0)
 default[:kerl][:path]     = "/usr/local/bin/kerl"


### PR DESCRIPTION
Also drop support for the previous Erlang 17.0 release candidates.
