### PR TITLE
Build Erlang Dialyzer PLTs in a separate optional step

### DIFF
--- a/ci_environment/kerl/attributes/source.rb
+++ b/ci_environment/kerl/attributes/source.rb
@@ -1,2 +1,3 @@
-default[:kerl][:releases] = %w(R14B02 R14B03 R14B04 R15B R15B01 R15B02 R15B03 R16B R16B01 R16B02 R16B03 R16B03-1 17.0)
-default[:kerl][:path]     = "/usr/local/bin/kerl"
+default[:kerl][:releases]  = %w(R14B02 R14B03 R14B04 R15B R15B01 R15B02 R15B03 R16B R16B01 R16B02 R16B03 R16B03-1 17.0)
+default[:kerl][:path]      = "/usr/local/bin/kerl"
+default[:kerl][:build_plt] = false

--- a/ci_environment/kerl/files/default/build_plt
+++ b/ci_environment/kerl/files/default/build_plt
@@ -2,4 +2,14 @@
 
 . "$1/activate"
 
-dialyzer --output_plt "${REBAR_PLT_DIR}/dialyzer.plt" --build_plt --apps `ls "$2" | sed 's/-.*//' | grep -v jinterface | grep -v erl_interface`
+dialyzer --output_plt "${REBAR_PLT_DIR}/dialyzer.plt" \
+         --build_plt \
+         --apps `ls "$2" | sed 's/-.*//' | grep -v jinterface | grep -v erl_interface`
+status=$?
+if [ $status -eq 2 ]; then
+    # dialyzer(3): exit status 2 - No problems were encountered,
+    # but warnings were emitted.
+    exit 0
+else
+    exit $status
+fi

--- a/ci_environment/kerl/recipes/source.rb
+++ b/ci_environment/kerl/recipes/source.rb
@@ -100,7 +100,7 @@ node.kerl.releases.each do |rel, build|
 
   execute "install Erlang #{rel}" do
     # cleanup is available starting with https://github.com/spawngrid/kerl/pull/28
-    command "#{node.kerl.path} install #{rel} #{installation_root}/#{rel} && #{node.kerl.path} cleanup #{rel} && rm -rf #{node.travis_build_environment.home}/.kerl/archives/*" # && ~/.build_plt #{installation_root}/#{rel} #{installation_root}/#{rel}/lib"
+    command "#{node.kerl.path} install #{rel} #{installation_root}/#{rel} && #{node.kerl.path} cleanup #{rel} && rm -rf #{node.travis_build_environment.home}/.kerl/archives/*"
 
     user    node.travis_build_environment.user
     group   node.travis_build_environment.group
@@ -108,5 +108,17 @@ node.kerl.releases.each do |rel, build|
     environment(env)
 
     not_if "#{node.kerl.path} list installations | grep #{rel}", :user => node.travis_build_environment.user, :environment => env
+  end
+
+
+  execute "generate Erlang #{rel} Dialyzer PLT" do
+    command "~/.build_plt #{installation_root}/#{rel} #{installation_root}/#{rel}/lib"
+
+    user    node.travis_build_environment.user
+    group   node.travis_build_environment.group
+
+    environment(env)
+
+    not_if "#{node.kerl.path} list installations | grep #{rel} && test -f #{installation_root}/#{rel}/dialyzer.plt", :user => node.travis_build_environment.user, :environment => env
   end
 end

--- a/ci_environment/kerl/recipes/source.rb
+++ b/ci_environment/kerl/recipes/source.rb
@@ -119,6 +119,7 @@ node.kerl.releases.each do |rel, build|
 
     environment(env)
 
+    only_if { node.kerl.build_plt }
     not_if "#{node.kerl.path} list installations | grep #{rel} && test -f #{installation_root}/#{rel}/dialyzer.plt", :user => node.travis_build_environment.user, :environment => env
   end
 end


### PR DESCRIPTION
It would be cool if the Travis boxes had PLTs prebuilt as doing that per-build is just a waste of time and CPU cycles (and leads to timeouts without some vile hackery).

However, since that's not the case at the moment, I've cleaned up the PLT generation a bit in order to prepare them for fetching from external storage during a build. The PLTs have absolute paths embedded so generating in a different env than they are intended to be used in is not an option.

This is my first encounter with Chef, so please shout if anything here smells.