### PR TITLE
Vagrantfile and role for standard worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Chef `run-lists` that are used to build the different VM images for Travis C
 All the required cookbooks are stored in this single repository (no Berkshelf/Librarian, no git modules). You can find more details about this approach in ["Making Breakfast: Chef at Airbnb"](http://nerds.airbnb.com/making-breakfast-chef-airbnb/).
 
 * Chef cookbooks currently must be compatible with **Chef 11**.
-* The VM template/basebox must be installed with **Ubuntu 12.04LTS**
+* The VM template/basebox should be installed with **Ubuntu 12.04LTS**, which is the supported plaform.
 
 ### Virtualization Technology
 
@@ -28,29 +28,36 @@ Cookbooks can be easily developed using [Vagrant](https://github.com/mitchellh/v
 
 There is a `Vagrantfile` in this project that includes a VirtualBox setup, though testing is possible with other [Vagrant providers](https://github.com/mitchellh/vagrant/wiki/Available-Vagrant-Plugins#providers). For VirtualBox, make sure to use Vagrant 1.6.2+ and VirtualBox 4.3.12+, or you might encounter [Vagrant #3341](https://github.com/mitchellh/vagrant/issues/3341).
 
-The included `Vagrantfile` defines multiple machines, where each machine is a target worker platform. It is set to provision the `worker_standard` role for each machine. There are other roles (`worker_ruby`, `worker_python`, etc.) but since `worker_standard` includes at least one version of every langauge it provides good cookbook coverage.
+The included `Vagrantfile` defines multiple machines, where each machine is a target worker platform:
+
+* `precise`: this VM is defined as `primary` as Ubuntu 12.04 is officially supported by travis-cookbooks
+* `trusty`: this VM is experimental and is not automatically started
+* `win8`: this VM is [experimental](https://github.com/travis-ci/travis-cookbooks/commits/ha-feature-windows) and is not automatically started
+
+By default, Vagrant is configured to provision the `worker_standard` role. There are [more possible setups](https://github.com/travis-ci/travis-images/tree/master/templates) (`worker_ruby`, `worker_python`, etc.) but since all Travis worker machines are based on `worker_standard` it provides good cookbook coverage. It is also possible to narrow down the Chef run list to only install a specific set of cookbooks, as commented in the `Vagrantfile` itself.
 
 #### Usage
 
 ```bash
 $ vagrant status
-# Displays available machines, e.g. win8, precise, trusty
-$ vagrant up precise
-# Starts just the precise machine
-$ vagrant provision precise
-# (Re-)provisions the trusty machine
+# Displays available machines, e.g. precise, trusty, win8
+
 $ vagrant up
-# Starts all available machines and tries to provision them... will take a long time
+# Starts the precise machine and tries to provision it... will take a long time.
+
+$ vagrant up trusty
+$ vagrant up win8
+# Starts experimental machines and tries to provision them...
 ```
 
-##### Windows Image
+#### Windows Image
 
-Vagrant will automatically install boxes for precise and trusty if you don't have them. Windows will not automatically install, and in fact licensing concerns have preventing anyone from publishing a Vagrant box that supports Windows on VirtualBox.
+Vagrant will automatically install boxes for Ubuntu Linux (`precise` and `trusty`) if you don't have them. Windows will not automatically install, and in fact licensing concerns have preventing anyone from publishing a Vagrant box that supports Windows on VirtualBox.
 
 The following Windows boxes are available:
 - [VagrantBox containing Windows on Hyper-V](http://vagrantbox.msopentech.com/) - are available from Microsoft Open Technologies, but you can only use Hyper-V if your host OS is Window... so don't waste your time downloading on Mac or Linux.
 - [Non-Vagrant VirtualBox images](http://modern.ie/en-us/virtualization-tools#downloads) - are available from the modern.ie. Follow [these instructions](https://github.com/WinRb/vagrant-windows#creating-a-base-box) to create your own Windows base box.
-- Use the cloud! Several of the [vagrant providers](https://github.com/mitchellh/vagrant/wiki/Available-Vagrant-Plugins#providers) are for clouds that have Windows images. This means you don't to wait for a large download (3.7G for the above options), sacrifice 2GB of local memory, or creating base images or Windows licensing. *Unfortunately*: communication with Windows is currently insecure and syncing folders (especially from non-Windows hosts) is not widely supported - so cloud providers are more of a future option unless you're willing to accept the known issues.
+- Go faster and simpler, use the cloud! Several of the [vagrant providers](https://github.com/mitchellh/vagrant/wiki/Available-Vagrant-Plugins#providers) are for clouds that have Windows images. *Unfortunately*: communication with Windows is currently insecure and syncing folders (especially from non-Windows hosts) is not widely supported - so cloud providers are more of a future option unless you're willing to accept the known issues.
 
 ## General Purpose Cookbooks
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,9 +5,47 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # In general, it is a good idea to use latest release of Chef 11.x,
+  # but please keep in mind that Travis team is provisioning with the version defined at
+  # https://github.com/travis-ci/travis-images/blob/master/lib/travis/cloud_images/vm_provisioner.rb
   config.omnibus.chef_version = :latest
 
-  config.vm.define :win8 do |win|
+  # Enable Vagrant plugins like vagrant-cachier and vagrant-vbguest
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+  end
+  # if Vagrant.has_plugin?("vagrant-vbguest")
+  #   config.vbguest.auto_update = true
+  # end
+
+  # VM tuning hints:
+  # - A big VM (RAM > 1024M) is recommended to speed up compilation/install time
+  # - A small VM (RAM < 1024M) is usually enough to verify a little set of isolated cookbooks
+  # - Real Travis workers are equipped with 3G of RAM
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 2048
+    vb.cpus = 4
+  end
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # The Travis CI Linux worker is currently based on Ubuntu 12.04LTS 64bit
+  # Pending: Refer to a basebox with Linux Kernel pinned on version 2.6
+  config.vm.define :precise, primary: true do |ubuntu|
+    ubuntu.vm.box = "ubuntu/precise64"
+  end
+
+  # Work in Progress: Support of Ubuntu 14.04LTS (not supported yet)
+  config.vm.define :trusty, autostart: false do |ubuntu|
+    ubuntu.vm.box = "ubuntu/trusty64"
+  end
+
+  # Work in Progress: Support of Windows 8 (not supported yet)
+  config.vm.define :win8, autostart: false do |win|
     win.vm.box = "win8"
     win.vm.communicator = "winrm"
     win.vm.guest = :windows
@@ -21,28 +59,29 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  config.vm.define :precise do |ubuntu|
-    ubuntu.vm.box = "hashicorp/precise64"
-  end
-
-  config.vm.define :trusty do |ubuntu|
-    ubuntu.vm.box = "ubuntu/trusty64"
-  end
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
-  # We're gonna need a bigger VM or the compilation/installs will take forever!
-  config.vm.provider "virtualbox" do |vb|
-    vb.memory = 2048
-    vb.cpus = 4
-  end
-
   config.vm.provision "chef_solo" do |chef|
     chef.log_level      = :info
     chef.cookbooks_path = "ci_environment"
+
+    # Role-based Provisioning:
     chef.roles_path = "roles"
     chef.add_role "worker_standard"
+
+    # Alternatively, you can disable `chef.add_role` above and specify a smaller run list:
+    # chef.add_recipe "apt"
+    # chef.add_recipe "travis_build_environment"
+    # chef.add_recipe "java"
+    # chef.add_recipe "..."
+    #
+    # chef.json = {
+    #   "apt" => {
+    #     :mirror => 'de'
+    #   },
+    #   "travis_build_environment" => {
+    #     "user" => 'vagrant'
+    #   },
+    # }
+
   end
+
 end

--- a/roles/worker_standard.rb
+++ b/roles/worker_standard.rb
@@ -1,3 +1,6 @@
+#
+# Role defintion based on https://github.com/travis-ci/travis-images/blob/master/templates/worker.standard.yml
+#
 name 'worker_standard'
 description 'Travis Standard Worker for Linux'
 default_attributes(
@@ -19,7 +22,6 @@ default_attributes(
     {
       'use_tmpfs_for_builds' => false,
       'user' => 'vagrant',      # Note - vagrant only!
-      'home' => '/home/vagrant' # Note - vagrant only!
     }
 )
 run_list(


### PR DESCRIPTION
I tried out creating and then packaging a worker box, as proposed in https://github.com/travis-ci/travis-ci/issues/2191.  It went surprisingly well!

This can be used not just for https://github.com/travis-ci/travis-ci/issues/2191, but also to write regression tests for https://github.com/travis-ci/travis-ci/issues/2046.

I'm trying to upload the box to and publish the metadata on vagrantcloud.com, but it'll take a while.  Creating your own is easy (but also takes a while):
- Run `vagrant --version` and make sure you have a recent version (I used 1.5.3)
- Run `vagrant up`
- Wait for a successful build (I had a couple minor problem, see below)
- Run `vagrant package --output travis-worker-linux.box`

The only issues I had:
- Thought I had to create the travis user, but I think this is solved with setting the user to vagrant in the role.
- The ark cookbook thought I was on freebsd for some reason and wanted to install gtar.  I just commented out [this line](https://github.com/travis-ci/travis-cookbooks/blob/d90bce2d38e782ed759a56d231963e5572b7b1eb/ci_environment/ark/attributes/default.rb#L10)
- This creates a very big vagrant box (3.6GB)
