### PR TITLE
Use consistent (with Ubuntu 14.04) build configuration

### DIFF
--- a/ci_environment/python/recipes/pyenv.rb
+++ b/ci_environment/python/recipes/pyenv.rb
@@ -44,6 +44,13 @@ end
 # Store a list of all of our bin dirs
 bindirs = Array.new
 
+# python-build environment variables
+build_environment = {
+  # Adapted from Ubuntu 14.04's python3.4 package
+  "PYTHON_CONFIGURE_OPTS" => "--enable-unicode=ucs4 --with-wide-unicode --enable-shared --enable-ipv6 --enable-loadable-sqlite-extensions --with-computed-gotos",
+  "PYTHON_CFLAGS" => "-g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security",
+}
+
 # Install the baked in versions of Python we are offering
 node.python.pyenv.pythons.each do |py|
   # Get our on disk name for this python
@@ -56,10 +63,7 @@ node.python.pyenv.pythons.each do |py|
   # Actually do the installation/building to the full version python
   execute "python-build #{py} /opt/python/#{py}" do
     creates "/opt/python/#{py}"
-    environment ({
-      "PYTHON_CONFIGURE_OPTS" => "--enable-unicode=ucs4 --with-wide-unicode",
-      "CFLAGS" => "-g -O2",
-    })
+    environment build_environment
   end
 
   # Add a nonstandard pythonX.Y.Z command in order to support multiple installs
@@ -120,6 +124,7 @@ template "/etc/profile.d/pyenv.sh" do
 
   variables({
     :bindirs => bindirs,
+    :build_environment => build_environment,
   })
 
   source "pyenv.sh.erb"

--- a/ci_environment/python/templates/default/pyenv.sh.erb
+++ b/ci_environment/python/templates/default/pyenv.sh.erb
@@ -1,2 +1,7 @@
 # Export the $PATH with the pyenv bindirs prepended to it
 export PATH=<%= @bindirs.join(':') %>:$PATH
+
+# Configure python-build for consistent build options
+<% @build_environment.each do |key, value| %>
+export <%= key %>="<%= value %>"
+<% end %>


### PR DESCRIPTION
This PR has two changes:
- Adapts the configure opts and cflags to more closely match that of Ubuntu's system packages
- Sets `PYTHON_CONFIGURE_OPTS` and `PYTHON_CFLAGS` in `/etc/profile.d/pyenv.sh`. This will allow people to have the same build options as travis used to built `/opt/python` if they invoke `python-build` themselves manually.
