### PR TITLE
Install unixodbc for Erlang packages

### DIFF
--- a/ci_environment/kerl/recipes/source.rb
+++ b/ci_environment/kerl/recipes/source.rb
@@ -24,6 +24,10 @@ package "curl" do
   action :install
 end
 
+package "unixodbc-dev" do
+  action :install
+end
+
 installation_root = "/home/#{node.travis_build_environment.user}/otp"
 
 directory(installation_root) do


### PR DESCRIPTION
This enables Erlang to be compilex with built-in ODBC support.

Fixes travis-ci/travis-ci#2254
