### PR TITLE
Don't set JAVA_HOME unless node.java is present

### DIFF
--- a/ci_environment/travis_build_environment/templates/default/ci_user/dot_bashrc.sh.erb
+++ b/ci_environment/travis_build_environment/templates/default/ci_user/dot_bashrc.sh.erb
@@ -97,7 +97,9 @@ if [ -f ~/.bash_aliases ]; then
     . ~/.bash_aliases
 fi
 
+<% if node.has_key?('java') %>
 export JAVA_HOME=<%= node.java.java_home %>
+<% end %>
 
 # enable programmable completion features (you don't need to enable
 # this, if it's already enabled in /etc/bash.bashrc and /etc/profile

--- a/ci_environment/travis_build_environment/templates/default/etc/environment.sh.erb
+++ b/ci_environment/travis_build_environment/templates/default/etc/environment.sh.erb
@@ -1,11 +1,13 @@
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-JAVA_HOME="<%= node.java.java_home %>"
+<% if node.has_key?('java') %>
+JAVA_HOME=<%= node.java.java_home %>
+<% end %>
 
 DEBIAN_FRONTEND=noninteractive
 
 TRAVIS=true
 CI=true
-CONTINUOUS_INTEGRATION=true 
+CONTINUOUS_INTEGRATION=true
 
 LC_CTYPE=en_US.UTF-8
 LC_ALL=en_US.UTF-8

--- a/ci_environment/travis_build_environment/templates/default/root/dot_bashrc.sh.erb
+++ b/ci_environment/travis_build_environment/templates/default/root/dot_bashrc.sh.erb
@@ -6,7 +6,9 @@
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
+<% if node.has_key?('java') %>
 export JAVA_HOME=<%= node.java.java_home %>
+<% end %>
 
 
 # If not running interactively, don't do anything


### PR DESCRIPTION
The `travis_build_environment` should not break if there's no java config.
