### PR TITLE
Add LLVM's bin directory to $PATH

### DIFF
--- a/ci_environment/clang/recipes/tarball.rb
+++ b/ci_environment/clang/recipes/tarball.rb
@@ -29,5 +29,5 @@ ark 'clang' do
   checksum      node['clang']['checksum']
   version       node['clang']['version']
 
-  has_binaries  %w(bin/clang bin/clang++ bin/llvm-link)
+  append_env_path true
 end


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/2262
by modifying $PATH, rather than symlinking every binary
in the package.
