### PR TITLE
Cooking Windows (messily)

### DIFF
--- a/ci_environment/travis_build_environment/metadata.rb
+++ b/ci_environment/travis_build_environment/metadata.rb
@@ -10,4 +10,14 @@ depends "sysctl"
 depends "openssh"
 depends "unarchivers"
 depends "iptables"
+
+# Windows only
 depends "chocolatey"
+
+# Version control systems
+depends "git"
+depends "mercurial"
+depends "subversion"
+
+# Tools & libraries
+depends "phantomjs"

--- a/ci_environment/travis_build_environment/recipes/common.rb
+++ b/ci_environment/travis_build_environment/recipes/common.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: travis_build_environment
+# Recipe:: common
+# Copyright 2011-2014, Travis CI Development Team <contact@travis-ci.org>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+# Shared across all worker types and platforms
+
+# Version control systems
+include_recipe "git"
+include_recipe "mercurial"
+include_recipe "subversion"

--- a/ci_environment/travis_build_environment/recipes/windows.rb
+++ b/ci_environment/travis_build_environment/recipes/windows.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: travis_build_environment
-# Recipe:: root
+# Recipe:: windows
 # Copyright 2011-2014, Travis CI Development Team <contact@travis-ci.org>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,3 +24,70 @@
 
 log "The Windows worker is still experimental... most things don't work"
 include_recipe "chocolatey"
+
+# TODO: Move from this quick & dirty recipe to separate (ideally community maintained) cookbooks.
+
+# Compilers
+
+# Microsoft Visual Studio Express
+
+  chocolatey "VisualStudio2013ExpressWeb" do
+  end
+
+# Go
+
+  # TODO: Needs 64-bit fix: cinst golang
+
+# PowerShell: Assume the version in the VM image is recent enough
+# OpenSSL
+
+  chocolatey "OpenSSL.Light" do
+  end
+
+# PhantonJS: Already in common recipe
+
+# ImageMagick
+  # TODO: imagemagick::devel or imagemagick::rmagick on Windows?
+  chocolatey "imagemagick" do
+  end
+
+# Runtimes
+
+# Ruby
+
+  # Note: Using Ruby 1.9 because DevKit isn't available in Chocolatey for Ruby 2
+
+  chocolatey "ruby" do
+    version "1.9.3.48400"
+  end
+
+  chocolatey "ruby.devkit" do
+  end
+
+# Java
+
+  # Note: Oracle, not OpenJDK
+  # Note: java.jdk didn't work
+
+  chocolatey "jdk8" do
+  end
+
+# Python
+
+  # Note: There is a PR to add Windows support to the python cookbook,
+  # see https://github.com/poise/python/pull/76
+
+  # Note: I didn't have any luck with virtualenvwrapper-powershell
+
+  chocolatey "python" do
+    # version '3.4.0.20140321'
+  end
+
+# Node.js
+
+  # Note: Use nodejs.install, nodejs doesn't include npm
+
+  chocolatey "nodejs.install" do
+  end
+
+# Go - Installed as part of compilers section

--- a/roles/worker_windows.rb
+++ b/roles/worker_windows.rb
@@ -29,5 +29,10 @@ run_list(
   #
   # Travis environment + build toolchain
   #
-  'recipe[travis_build_environment::windows]',
+  'recipe[travis_build_environment::common]',
+
+  #
+  # Quick and dirty Windows setup, should be split into proper community cookbooks
+  #
+  'recipe[travis_build_environment::windows]'
 )


### PR DESCRIPTION
This PR contains a quick-and-dirty recipe for creating a standard worker on Windows. It meets most of the requirements of https://github.com/travis-ci/travis-ci/issues/2379. See https://github.com/travis-ci/travis-cookbooks/pull/324 for a test suite to verify these recipes... and to allow us to refactor towards a cleaner approach in the future.

The things that make this quick and dirty are:
- The runtimes (Ruby, Node, etc) do not have version switchers (nodist, uru, etc). It meets the worker requirement that "every worker has at least one version", but we'll need version managers for the language-specific workers.
- Most of the work is done in a single recipe that just call chocolatey with the default options (installing the latest available package). It'd be better if the work was moved to the appropriate cookbooks (e.g. ruby) that provide attributes and post-configuration.
- I created a new role, worker_windows, rather than changing worker_standard to support windows. I think it may be good to merge them eventually, but we need to discuss how we're going to do platform-agnostic roles and cookbooks first.

Things that work well:
- The recipes included in common.rb - git, mercurial, and subversion - provide a good example of how everything should probably work. They have cookbooks that support windows, so the definition of the role/build_environment becomes declarative: "The standard_worker should have git git" not "Install git with chocolatey for the standard worker (on windows)"
- Berkshelf seems to be working well, but we need to discuss further how to move forward w/ Berkshelf and away from ci_environment/worker_environment folders.

Here's the current Berksfile, since it's not shown in the PR:
```ruby
source "https://api.berkshelf.com"

cookbook 'travis_build_environment', path: 'ci_environment/travis_build_environment'
# Unpublished dependencies of travis_build_environment which api.berkshelf.com won't find
cookbook 'unarchivers', path: 'ci_environment/unarchivers'
```

So `berks vendor` or `berks package` actually fetch the majority of the cookbooks via http://community.opscode.com/, via api.berkshelf.com. The `ci_environment` folder is only being used for the two cookbooks I need that aren't published to the opscode community: `travis_build_environment` and `unarchivers`.

One option, if it's necessary to keep the split between `ci_environment` and `worker_host` at all, is to create a Berksfile.ci_environment and a Berksfile.worker_host, and then use:
```
berks vendor --berksfile=Berksfile.ci_environment ci_environment
berks vendor --berksfile=Berksfile.ci_environment ci_environment
```