### PR TITLE
Add LDAP (with SASL) support to PHP.

### DIFF
--- a/ci_environment/phpbuild/templates/default/default_configure_options.erb
+++ b/ci_environment/phpbuild/templates/default/default_configure_options.erb
@@ -43,3 +43,5 @@
 --with-kerberos
 --with-imap
 --with-imap-ssl
+--with-ldap
+--with-ldap-sasl


### PR DESCRIPTION
Add LDAP (with SASL) support to PHP.
fixes https://github.com/travis-ci/travis-ci/issues/1096
