### PR TITLE
Eradicate use of sudo from jdk_switcher_rc

### DIFF
--- a/ci_environment/java/templates/ubuntu/jdk_switcher.sh.erb
+++ b/ci_environment/java/templates/ubuntu/jdk_switcher.sh.erb
@@ -56,8 +56,6 @@ else
     ORACLEJDK8_JAVA_HOME="/usr/lib/jvm/java-8-oracle"
 fi
 
-UJA="update-java-alternatives"
-
 switch_to_openjdk6 () {
     echo "Switching to OpenJDK6 ($OPENJDK6_UJA_ALIAS), JAVA_HOME will be set to $OPENJDK6_JAVA_HOME"
     export JAVA_HOME="$OPENJDK6_JAVA_HOME"


### PR DESCRIPTION
Instead of `update-java-alternative`, manage `$JAVA_HOME` and `$PATH` ourselves so that we can switch JDK versions without `sudo`.
