### PR TITLE
Add PyPy3 support

### DIFF
--- a/ci_environment/python/attributes/default.rb
+++ b/ci_environment/python/attributes/default.rb
@@ -31,7 +31,6 @@ default['python']['pyenv']['pythons'] = [
     "3.2.5",
     "pypy3-2.3.1",
     "pypy-2.3.1",
-    "pypy-2.3",
     "pypy-2.2.1",
 ]
 


### PR DESCRIPTION
pyenv supports PyPy3.

See https://github.com/yyuu/pyenv/commit/ade2bf2a0da0ea7774b4e7dda6572f84caf25916

Addresses https://github.com/travis-ci/travis-ci/issues/2444.
