### PR TITLE
Prevent jdk_switcher from resetting PATH

### DIFF
--- a/ci_environment/java/templates/ubuntu/jdk_switcher.sh.erb
+++ b/ci_environment/java/templates/ubuntu/jdk_switcher.sh.erb
@@ -105,7 +105,7 @@ warn_gcj_user () {
 
 remove_dir_from_path() {
     local target=$(echo $1 | sed -e 's:/*$::') # remove all occurrences of / at the end
-    PATH=:$(echo $PATH: | sed -e 's_/*:_:_g'):
+    PATH="$(echo :$PATH: | sed -e 's_/*:_:_g')"
     PATH="${PATH//:$target:/:}"
     PATH="${PATH#:}"
     PATH="${PATH%:}"


### PR DESCRIPTION
Since `/etc/profile.d/load_jdk_switcher.sh` always sources
`$HOME/.jdk_switcher_rc`, jdk_switcher reverting to the original `$PATH`
causes problems when other stuff (such as PostgreSQL service)
starts a login shell after manipulating `$PATH` and subshell is expected
to find stuff in the modified `$PATH`.
