### PR TITLE
Improved JRuby options.

### DIFF
--- a/ci_environment/travis_build_environment/files/default/ci_user/travis_environment.sh
+++ b/ci_environment/travis_build_environment/files/default/ci_user/travis_environment.sh
@@ -17,13 +17,16 @@ export RACK_ENV=test
 # http://getcomposer.org/doc/03-cli.md#composer-no-interaction
 export COMPOSER_NO_INTERACTION=1
 
-# --server for the server (C2) JVM JIT compiler
+# --client for older OpenJDK C1 compiler, with faster startup
+#
+# -J-XX:+TieredCompilation  To enable the equivalent of the C1 compiler on
+# -J-XX:TieredStopAtLevel=1 newer versions of OpenJDK
+#
 # -Xcext.enabled=false to disable C extensions, running them in production
 #                      on JRuby is a bad idea but developers often have no
 #                      clue they depend on C extensions
+#
 # -J-Xss2m bumps stack size to 2 MB
-# -J-Xmx256m sets maximum allowed JVM heap size to 256 MB (64m by default)
-# -J-XX:+TieredCompilation to enable tiered compilation mode (long story short:
-#                          to improve startup time, especially on JDK 7+)
-# -Xcompile.invokedynamic=false disables invokedynamic which seemingly causes 32 bit OpenJDKs (6 and 7) to segfault
-export JRUBY_OPTS="--server -Xcext.enabled=false -Xcompile.invokedynamic=false -J-Xss2m -J-Xmx256m -J-XX:+TieredCompilation"
+#
+# -Xcompile.invokedynamic=false disables invokedynamic which is still somewhat experimental
+export JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -Xcext.enabled=false -J-Xss2m -Xcompile.invokedynamic=false"


### PR DESCRIPTION
Changes are as follows, with justification:
- --server to --client

--server is really only useful on long-running processes...longer
running than a test build. Tests are also a worst-case scenario
for optimization, since most code will only run once or a few
times. --client provides the fastest startup and shortest warmup
time with reduced long-run performance, making it a better choice
for test runs.
- Add -J-XX:TieredStopAtLevel=1

On 64-bit and newer JVMs, the -client and -server flags are no
longer honored. Instead, the JVMs either run server all the time
or a "tiered" compiler that combines -client and -server. This
flag forces that tiered compiler to only do client-level
optimization, equivalent to the fast-starting -client mode.
- Remove memory setting

It _is_ true that the JVM itself defaults to a 64MB heap limit,
but JRuby already adjusts that to 500MB. This flag is actually
reducing available memory.
## 

I believe these flags will work well on all recent JRuby versions
(within the last few years) and all Hotspot-based JVMs (OpenJDK,
Oracle, IcedTea) as far back as the 1.6 line.
