### PR TITLE
update default.rb to include android build tools

### DIFF
--- a/ci_environment/android-sdk/attributes/default.rb
+++ b/ci_environment/android-sdk/attributes/default.rb
@@ -17,7 +17,12 @@ default['android-sdk']['download_url']   = "http://dl.google.com/android/android
 # Add 'tools' to the list below if you wish to get the latest version,
 # without having to adapt 'version' and 'checksum' attributes of this cookbook.
 # Note that it will require (waste) some extra download effort.
+#
+# build-tools needs to be maintained. Theoretically, there's a meta-taget
+# for it.
+#
 default['android-sdk']['components']     = %w(platform-tools
+                                              build-tools-20.0.0
                                               android-19
                                               sys-img-armeabi-v7a-android-19
                                               android-18


### PR DESCRIPTION
Explicitly add the build-tools rev 20 to the components group. Ant fails when there are no build tools, and somewhere the build-tools-\* package didn't get installed. r20 is the latest as of 2014-8-18, but will need to be updated.

Basic proof: https://github.com/indrora/Atomic/compare/359a055aaf53...8096f5774697

Failing build: https://travis-ci.org/indrora/Atomic/builds/32836533

Passing build: https://travis-ci.org/indrora/Atomic/builds/32880563
