### PR TITLE
Revert "update default.rb to include android build tools"

### DIFF
--- a/ci_environment/android-sdk/attributes/default.rb
+++ b/ci_environment/android-sdk/attributes/default.rb
@@ -17,12 +17,7 @@ default['android-sdk']['download_url']   = "http://dl.google.com/android/android
 # Add 'tools' to the list below if you wish to get the latest version,
 # without having to adapt 'version' and 'checksum' attributes of this cookbook.
 # Note that it will require (waste) some extra download effort.
-#
-# build-tools needs to be maintained. Theoretically, there's a meta-taget
-# for it.
-#
 default['android-sdk']['components']     = %w(platform-tools
-                                              build-tools-20.0.0
                                               android-19
                                               sys-img-armeabi-v7a-android-19
                                               android-18


### PR DESCRIPTION
Sorry @indrora @BanzaiMan, but I disagree about travis-ci/travis-cookbooks#359 and I propose to revert it. 

The `build-tools-x.y.z` components are intentionally not preinstalled in the VM image (see travis-ci/travis-ci#2296 for more details), to force each project to explicitly declare their required version (exactly like @indrora did in https://github.com/indrora/Atomic/commit/8096f5774697e6562328a071502c2776459d1fe9).

See also our recommendation about http://docs.travis-ci.com/user/languages/android/#Pre-installed-components.
