### PR TITLE
Rollback to ext-memcached 2.1

### DIFF
--- a/ci_environment/php/attributes/default.rb
+++ b/ci_environment/php/attributes/default.rb
@@ -20,7 +20,7 @@ default[:php][:multi][:extensions] = {
       ./configure && make && make install
     EOF
     'script'   => <<-EOF
-      pecl download memcached-2.2.0
+      pecl download memcached-2.1.0
       tar zxvf memcached*.tgz && cd memcached*
       make clean
       phpize


### PR DESCRIPTION
This fixes issues with php 5.2 as raised in https://github.com/travis-ci/travis-ci/issues/2743.
