### PR TITLE
Prevent CouchDB from starting on boot

### DIFF
--- a/ci_environment/couchdb/recipes/ppa.rb
+++ b/ci_environment/couchdb/recipes/ppa.rb
@@ -33,3 +33,10 @@ service "couchdb" do
   # intentionally disabled on boot. MK.
   action [:disable, :start]
 end
+
+file '/etc/init/couchdb.override' do
+  owner 'root'
+  group 'root'
+  mode 0644
+  content 'manual'
+end


### PR DESCRIPTION
It is hypothesized that the change of PPA to the official one (https://github.com/travis-ci/travis-cookbooks/commit/e622123bfef4b88cff8457e15a3e599033013512) switched the init script to Upstart, which apparently does not respect Chef's `disable` action.

This will prevent CouchDB from starting on boot (and consuming ~250 MB of memory).

This requires all images to be re-provisioned. Until then, we should hack travis-build to shut down couchdb at the start of the build.
