### PR TITLE
Update nvm to v0.17.1

### DIFF
--- a/ci_environment/nodejs/files/default/nvm.sh
+++ b/ci_environment/nodejs/files/default/nvm.sh
@@ -808,7 +808,6 @@ nvm() {
       mkdir -p "$NVM_DIR/alias"
       if [ $# -le 2 ]; then
         local DEST
-        local ALIAS
         for ALIAS in "$NVM_DIR"/alias/"$2"*; do
           if [ -e "$ALIAS" ]; then
             DEST="$(cat "$ALIAS")"
@@ -883,7 +882,7 @@ nvm() {
       nvm_version $2
     ;;
     "--version" )
-      echo "0.17.0"
+      echo "0.17.1"
     ;;
     "unload" )
       unset -f nvm nvm_print_versions nvm_checksum nvm_ls_remote nvm_ls nvm_remote_version nvm_version nvm_rc_version nvm_version_greater nvm_version_greater_than_or_equal_to > /dev/null 2>&1


### PR DESCRIPTION
Fixes an issue in zsh with some spurious `nvm alias` output.
