### PR TITLE
Create ramfs data directories

### DIFF
--- a/ci_environment/postgresql/templates/ubuntu/initd_postgresql.erb
+++ b/ci_environment/postgresql/templates/ubuntu/initd_postgresql.erb
@@ -54,12 +54,13 @@ fi
 
 <% if node['postgresql']['data_on_ramfs'] %>
 # Copy initial databases to RAMFS
-if [ ! -d <%= node['postgresql']['data_dir'] %> ]; then
-    mkdir <%= node['postgresql']['data_dir'] %>
-    for v in /var/lib/postgresql/*; do
-        cp -rp $v <%= node['postgresql']['data_dir'] %>/
-    done
-fi
+for data_dir in /var/lib/postgresql/*; do
+    v=$(basename $data_dir)
+    if [ ! -d <%= node['postgresql']['data_dir'] %>/$v ]; then
+        mkdir -p <%= node['postgresql']['data_dir'] %>/$v
+        cp -rp $data_dir <%= node['postgresql']['data_dir'] %>/
+    fi
+done
 <% end %>
 
 case "$1" in


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/2514

If /var/ramfs/postgresql exists already, `cp` is not invoked,
leaving /var/ramfs/postgresql/9.3 nonexistent under some circumstances.

This PR ensures that the data are properly copied on every invocation of this script if they do not exist already.
