### PR TITLE
Android emulator wait fix for all ADB/emulators

### DIFF
--- a/ci_environment/android-sdk/files/default/android-wait-for-emulator
+++ b/ci_environment/android-sdk/files/default/android-wait-for-emulator
@@ -10,16 +10,16 @@ timeout_in_sec=60
 
 until [[ "$bootanim" =~ "stopped" ]]; do
   bootanim=`adb -e shell getprop init.svc.bootanim 2>&1 &`
-  if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline" ]]; then
+  if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
+    || "$bootanim" =~ "running" ]]; then
     let "failcounter += 1"
     echo "Waiting for emulator to start"
     if [[ $failcounter -gt timeout_in_sec ]]; then
       echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
       exit 1
     fi
-  elif [[ "$bootanim" =~ "running" ]]; then
-    echo "Emulator is ready"
-    exit 0
   fi
   sleep 1
 done
+
+echo "Emulator is ready"


### PR DESCRIPTION
- See https://github.com/travis-ci/travis-ci/issues/2932
- Don't finish waiting if the boot animation is still running
