### PR TITLE
Increase timeout for Android emulator wait

### DIFF
--- a/ci_environment/android-sdk/files/default/android-wait-for-emulator
+++ b/ci_environment/android-sdk/files/default/android-wait-for-emulator
@@ -6,7 +6,7 @@ set +e
 
 bootanim=""
 failcounter=0
-timeout_in_sec=60
+timeout_in_sec=360
 
 until [[ "$bootanim" =~ "stopped" ]]; do
   bootanim=`adb -e shell getprop init.svc.bootanim 2>&1 &`


### PR DESCRIPTION
- Some emulator images can take 5+ minutes to complete booting

Our tests using Android 4.4 x86 Google APIs emulator images were failing with the updated v2 emulator wait script, which had put in a waiting limit of 60 seconds.
