### PR TITLE
docker-collectd: report disk usage in percentages

### DIFF
--- a/worker_host/travis_worker_collectd/recipes/ec2-docker.rb
+++ b/worker_host/travis_worker_collectd/recipes/ec2-docker.rb
@@ -11,11 +11,13 @@ end
 collectd_plugin "df" do
   options :mount_point => "/",
           :report_reserved => false,
-          :report_inodes => false
+          :report_inodes => false,
+          :values_percentage => true
 end
 
 collectd_plugin "df" do
   options :mount_point => "/mnt",
           :report_reserved => false,
-          :report_inodes => false
+          :report_inodes => false,
+          :values_percentage => true
 end


### PR DESCRIPTION
We're deploying this to machines with varying disk sizes, so tracking the percentages makes it easier to set up alerts.

Docs for this option is in the [`collectd.conf(5)` man page](http://collectd.org/documentation/manpages/collectd.conf.5.shtml#valuespercentage_true_false).
