### PR TITLE
Enable DBA functions for PHP

### DIFF
--- a/ci_environment/phpbuild/templates/default/default_configure_options.erb
+++ b/ci_environment/phpbuild/templates/default/default_configure_options.erb
@@ -45,3 +45,6 @@
 --with-imap-ssl
 --with-ldap=shared
 --with-ldap-sasl
+--enable-dba
+--with-cdb
+--with-inifile


### PR DESCRIPTION
Enable the built-in DBA providers (cdb, flatfile and inifile) for PHP.
