### PR TITLE
Add recipe to install Open JDK 8

### DIFF
--- a/ci_environment/java/attributes/default.rb
+++ b/ci_environment/java/attributes/default.rb
@@ -7,6 +7,7 @@ default['java']['default_version'] = 'oraclejdk7'
 default['java']['alternate_versions'] = []
 default['java']['openjdk6']['jvm_name'] = "java-1.6.0-openjdk-#{node['java']['arch']}"
 default['java']['openjdk7']['jvm_name'] = "java-1.7.0-openjdk-#{node['java']['arch']}"
+default['java']['openjdk8']['jvm_name'] = "java-1.8.0-openjdk-#{node['java']['arch']}"
 default['java']['oraclejdk7']['jvm_name'] = 'java-7-oracle'
 default['java']['oraclejdk7']['install_jce_unlimited'] = true
 default['java']['oraclejdk7']['pinned_release'] = nil

--- a/ci_environment/java/metadata.rb
+++ b/ci_environment/java/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Travis CI Team"
 maintainer_email  "contact@travis-ci.org"
 license           "Apache 2.0"
 description       "Installs different Java Development Kits (JDK)"
-version           "2.0.0"
+version           "2.1.0"
 
 supports 'ubuntu', '>= 12.04'
 

--- a/ci_environment/java/recipes/openjdk-r.rb
+++ b/ci_environment/java/recipes/openjdk-r.rb
@@ -1,0 +1,11 @@
+
+apt_repository "openjdk-r-java-ppa" do
+  uri          "http://ppa.launchpad.net/openjdk-r/ppa/ubuntu"
+  distribution node['lsb']['codename']
+  components   ["main"]
+  key          "86F44E2A"
+  keyserver    "keyserver.ubuntu.com"
+
+  action :add
+end
+

--- a/ci_environment/java/recipes/openjdk8.rb
+++ b/ci_environment/java/recipes/openjdk8.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: java
+# Recipe:: openjdk8
+#
+# Copyright 2014, Travis CI Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "java::openjdk-r"
+
+package "openjdk-8-jdk"
+

--- a/ci_environment/java/recipes/openjdk8.rb
+++ b/ci_environment/java/recipes/openjdk8.rb
@@ -17,7 +17,17 @@
 # limitations under the License.
 #
 
-include_recipe "java::openjdk-r"
+# As of Ubuntu 14.10 (Vivid), OpenJDK is available in main Ubuntu package repository
+if Chef::VersionConstraint.new("<= 14.04").include?(node['platform_version'])
+  include_recipe "java::openjdk-r"
+end
 
 package "openjdk-8-jdk"
+
+# openjfx package is not available for precise (12.04)
+# openjfx package is NOT YET available for trusty (14.04)
+# See https://bugs.launchpad.net/ubuntu/+source/openjdk-8/+bug/1398660
+if Chef::VersionConstraint.new(">= 14.10").include?(node['platform_version'])
+  package "openjfx"
+end
 

--- a/ci_environment/java/templates/ubuntu/jdk_switcher.sh.erb
+++ b/ci_environment/java/templates/ubuntu/jdk_switcher.sh.erb
@@ -27,6 +27,14 @@ else
     OPENJDK7_JAVA_HOME="/usr/lib/jvm/java-7-openjdk"
 fi
 
+if [[ -d "/usr/lib/jvm/java-8-openjdk-$ARCH_SUFFIX" ]] ; then
+  OPENJDK8_UJA_ALIAS="java-1.8.0-openjdk-$ARCH_SUFFIX"
+  OPENJDK8_JAVA_HOME="/usr/lib/jvm/java-8-openjdk-$ARCH_SUFFIX"
+else
+  OPENJDK8_UJA_ALIAS="java-1.7.0-openjdk"
+  OPENJDK8_JAVA_HOME="/usr/lib/jvm/java-7-openjdk"
+fi
+
 # The java::oraclejdk7 recipe from github.com/travis-ci/travis-cookbooks
 # takes care of this alias. We take it for granted here. MK.
 if [[ -d "/usr/lib/jvm/java-7-oracle-$ARCH_SUFFIX" ]] ; then
@@ -61,6 +69,13 @@ switch_to_openjdk7 () {
     export PATH=$JAVA_HOME/bin:$PATH
 }
 
+switch_to_openjdk8 () {
+  echo "Switching to OpenJDK8 ($OPENJDK8_UJA_ALIAS), JAVA_HOME will be set to $OPENJDK8_JAVA_HOME"
+  remove_dir_from_path $JAVA_HOME/bin
+  export JAVA_HOME="$OPENJDK8_JAVA_HOME"
+  export PATH=$JAVA_HOME/bin:$PATH
+}
+
 switch_to_oraclejdk7 () {
     echo "Switching to Oracle JDK7 ($ORACLEJDK7_UJA_ALIAS), JAVA_HOME will be set to $ORACLEJDK7_JAVA_HOME"
     remove_dir_from_path $JAVA_HOME/bin
@@ -81,6 +96,10 @@ print_home_of_openjdk6 () {
 
 print_home_of_openjdk7 () {
     echo "$OPENJDK7_JAVA_HOME"
+}
+
+print_home_of_openjdk8 () {
+    echo "$OPENJDK8_JAVA_HOME"
 }
 
 print_home_of_oraclejdk7 () {
@@ -124,6 +143,9 @@ switch_jdk()
         openjdk7|jdk7|1.7.0|1.7|7.0)
             switch_to_openjdk7
             ;;
+         openjdk8|jdk8|1.8.0|1.8|8.0)
+            switch_to_openjdk8
+            ;;
         oraclejdk6|oraclejdk1.6|oraclejdk1.6.0|oracle6|oracle1.6.0|oracle6.0|sunjdk6|sun6)
             warn_sunjdk6_eol
             false
@@ -159,6 +181,9 @@ print_java_home()
             ;;
         openjdk7|jdk7|1.7.0|1.7|7.0)
             print_home_of_openjdk7
+            ;;
+        openjdk8|jdk8|1.8.0|1.8|8.0)
+            print_home_of_openjdk8
             ;;
         oraclejdk6|oraclejdk1.6|oraclejdk1.6.0|oracle6|oracle1.6.0|oracle6.0|sunjdk6|sun6)
             warn_sunjdk6_eol

--- a/ci_environment/java/templates/ubuntu/jdk_switcher.sh.erb
+++ b/ci_environment/java/templates/ubuntu/jdk_switcher.sh.erb
@@ -28,11 +28,11 @@ else
 fi
 
 if [[ -d "/usr/lib/jvm/java-8-openjdk-$ARCH_SUFFIX" ]] ; then
-  OPENJDK8_UJA_ALIAS="java-1.8.0-openjdk-$ARCH_SUFFIX"
-  OPENJDK8_JAVA_HOME="/usr/lib/jvm/java-8-openjdk-$ARCH_SUFFIX"
+    OPENJDK8_UJA_ALIAS="java-1.8.0-openjdk-$ARCH_SUFFIX"
+    OPENJDK8_JAVA_HOME="/usr/lib/jvm/java-8-openjdk-$ARCH_SUFFIX"
 else
-  OPENJDK8_UJA_ALIAS="java-1.7.0-openjdk"
-  OPENJDK8_JAVA_HOME="/usr/lib/jvm/java-7-openjdk"
+    OPENJDK8_UJA_ALIAS="java-1.8.0-openjdk"
+    OPENJDK8_JAVA_HOME="/usr/lib/jvm/java-8-openjdk"
 fi
 
 # The java::oraclejdk7 recipe from github.com/travis-ci/travis-cookbooks


### PR DESCRIPTION
:construction: **work in progress, please don't merge yet** :construction: 

I tested a few java builds and everything ran fine, but there are still some open issues to address:

 * [x] **Without JFX support** (`$JAVA_HOME/jre/lib/ext/jfxrt.jar`, ...), because these bits are not packaged by `ppa:openjdk/ppa` (unlike `oraclejdk8` package from ppa:webupd8team/java
  * as agreed with @BanzaiMan, won't be part of `openjdk8` for the moment (to be documented).
  * not planned for precise (12.04)
  * might be possible in the future for trusty (14.04), pending on [Launchpad Bug 1398660](https://bugs.launchpad.net/ubuntu/+source/openjdk-8/+bug/1398660)
  * part of the default packaging for 14.10+
 * [ ] Is there other core components of JDK8 specification that are missing? (Nashorn is available, but I don't know yet a way to verify, excepted `diff -r`)
 * [x] Support of Java Cryptography Extension (JCE) Unlimited Strength (validated with https://github.com/simi/travis-jce-unlimited-test, automatically shipped with ubuntu package, like for version 6 and 7)
 * [ ] QA testing

@BanzaiMan feel free to drop 9c466abb39ec8ae91a838454f7760c6ced5ea044 (additional jdk_switcher aliases)