### PR TITLE
Remove older versions of Python

### DIFF
--- a/ci_environment/python/attributes/default.rb
+++ b/ci_environment/python/attributes/default.rb
@@ -27,13 +27,10 @@ default['python']['pyenv']['pythons'] = [
     "2.7.9",
     "2.6.9",
     "3.4.2",
-    "3.4.0",
     "3.3.5",
     "3.2.5",
     "pypy-2.4.0",
-    "pypy-2.3.1",
     "pypy3-2.4.0",
-    "pypy3-2.3.1",
 ]
 
 default['python']['pyenv']['aliases'] = {


### PR DESCRIPTION
Unless there are people pinning exactly to 3.4.0 instead of 3.4 (and so on) having these Pythons here will just increase the time required to build the image and increase the size of the image itself.
