### PR TITLE
Support erlang 17.4 with kerl

### DIFF
--- a/ci_environment/kerl/attributes/source.rb
+++ b/ci_environment/kerl/attributes/source.rb
@@ -1,2 +1,2 @@
-default[:kerl][:releases] = %w(R14B02 R14B03 R14B04 R15B R15B01 R15B02 R15B03 R16B R16B01 R16B02 R16B03 R16B03-1 17.0 17.1 17.3)
+default[:kerl][:releases] = %w(R14B02 R14B03 R14B04 R15B R15B01 R15B02 R15B03 R16B R16B01 R16B02 R16B03 R16B03-1 17.0 17.1 17.3 17.4)
 default[:kerl][:path]     = "/usr/local/bin/kerl"


### PR DESCRIPTION
Erlang 17.3 has some problems when using SSL with the inets module. The later patch releases (tested with OTP-17.3.4) are working but these are unfortunately not available through kerl. The recent Erlang 17.4 should work fine.
