### PR TITLE
Update SDK Tools to v.24.0.2 and remove wear-20 sys-img

### DIFF
--- a/ci_environment/android-sdk/attributes/default.rb
+++ b/ci_environment/android-sdk/attributes/default.rb
@@ -5,8 +5,8 @@ default['android-sdk']['owner']          = node['travis_build_environment']['use
 default['android-sdk']['group']          = node['travis_build_environment']['group']
 default['android-sdk']['setup_root']     = nil  # ark defaults (/usr/local) is used if this attribute is not defined
 
-default['android-sdk']['version']        = '24.0.1'
-default['android-sdk']['checksum']       = 'bb3754524a8f6700c2898617c9d8836a987a8aa43d0e922885cd7a98ca79b281'
+default['android-sdk']['version']        = '24.0.2'
+default['android-sdk']['checksum']       = 'c90d361406d5c1dc462342d931c5afda4c081d13708e9fb64c81a29b3d0bee8e'
 default['android-sdk']['download_url']   = "http://dl.google.com/android/android-sdk_r#{node['android-sdk']['version']}-linux.tgz"
 
 #
@@ -25,7 +25,6 @@ default['android-sdk']['components']     = %w(platform-tools
                                               android-21
                                               sys-img-armeabi-v7a-android-21
                                               android-20
-                                              sys-img-armeabi-v7a-android-wear-20
                                               android-19
                                               sys-img-armeabi-v7a-android-19
                                               android-18


### PR DESCRIPTION
Update SDK Tools version to 24.0.2
Update SDK Tools checksum (sha256sum)
Remove sys-img-armeabi-v7a-android-wear-20 installation by default

Google released a new version of SDK tools, further information here:
https://developer.android.com/sdk/index.html#Other

Download:
http://dl.google.com/android/android-sdk_r24.0.2-linux.tgz

There is a new version sys-img-armeabi-v7a-android-wear-21 and a issue using
docker about available space. This is a quickfix to gain space (1Gb unzipped).
