### PR TITLE
Cassandra 2.1.2

### DIFF
--- a/ci_environment/cassandra/attributes/default.rb
+++ b/ci_environment/cassandra/attributes/default.rb
@@ -1,4 +1,4 @@
-cassandra_version = "2.0.9"
+cassandra_version = "2.1.2"
 
 default[:cassandra] = {
   :version => cassandra_version,


### PR DESCRIPTION
Some changes to CQL warrant an upgrade for our Cassandra tests -- namely the use of `UNLOGGED` for counter batches instead of `COUNTER`.