### PR TITLE
Install PHP 5.2.17 from custom archive

### DIFF
--- a/ci_environment/php/recipes/5.2.17.rb
+++ b/ci_environment/php/recipes/5.2.17.rb
@@ -1,0 +1,29 @@
+include_recipe "bison"
+include_recipe "libreadline"
+
+include_recipe "phpenv"
+include_recipe "phpbuild"
+
+# This recipe downloads our own 5.2.17 archive for Precise
+
+if node[:platform] == 'ubuntu' && node[:platform_version] == '12.04'
+  require 'tmpdir'
+
+  local_archive = File.join(Dir.tmpdir, 'php-5.2.17.tar.bz2')
+
+  remote_file local_archive do
+    source 'https://s3.amazonaws.com/travis-php-archives/php-5.2.17.tar.bz2'
+    checksum '5deb018f585fb40d781917e6cd744f3ecaf8aabbc6eaf53d4f1300e61d8fd915'
+  end
+
+  bash 'Expand PHP 5.2.17 archive' do
+    user node.travis_build_environment.user
+    group node.travis_build_environment.group
+
+    code <<-EOF
+      tar xjf #{local_archive} --directory #{File.join(node.travis_build_environment.home, '.phpenv', 'versions')}
+    EOF
+
+    not_if File.exist?(File.join(node.travis_build_environment.home, '.phpenv', 'versions', '5.2.17'))
+  end
+end

--- a/vm_templates/common/php.yml
+++ b/vm_templates/common/php.yml
@@ -3,6 +3,7 @@ json:
     github_oauth_token: 2d8490a1060eb8e8a1ae9588b14e3a039b9e01c6
 recipes:
   - php::multi
+  - php::5.2.17
   - composer
   - system_info
   - sweeper


### PR DESCRIPTION
It is not possible to install PHP 5.2.17 with expected utilities
from the cookbooks.

Instead, we download and install the archive from an old image.

Closes https://github.com/travis-ci/travis-ci/issues/3152