### PR TITLE
Update Node to v0.12.0 stable by default

### DIFF
--- a/vm_templates/common/node-js.yml
+++ b/vm_templates/common/node-js.yml
@@ -9,7 +9,6 @@ json:
       - 0.12.0
     aliases:
       "0.10": '0.1'
-      "0.12": '0.1'
       0.11.16: node-head
       0.11.16: node-unstable
     default: 0.12.0

--- a/vm_templates/common/node-js.yml
+++ b/vm_templates/common/node-js.yml
@@ -5,12 +5,14 @@ json:
       - 0.8.27
       - 0.10.18
       - 0.10.36
-      - 0.11.15
+      - 0.11.16
+      - 0.12.0
     aliases:
       "0.10": '0.1'
-      0.11.15: node-head
-      0.11.15: node-unstable
-    default: 0.10.36
+      "0.12": '0.1'
+      0.11.16: node-head
+      0.11.16: node-unstable
+    default: 0.12.0
 recipes:
   - nodejs::multi
   - nodejs::iojs


### PR DESCRIPTION
http://blog.nodejs.org/2015/02/06/node-v0-12-0-stable/

Not sure I got the alias correct for 0.12.x though, as in I've no idea what the "0.1" refers to on that line ;)

Also bumps Node 0.11.15 unstable to 0.11.16 http://blog.nodejs.org/2015/01/30/node-v0-11-16-unstable/

Note: I couldn't find any references to a 0.13.x release to become the new "unstable" thus bumping the 0.11.x version only http://blog.nodejs.org