### PR TITLE
Install Python 3 runtime

### DIFF
--- a/ci_environment/python/recipes/package.rb
+++ b/ci_environment/python/recipes/package.rb
@@ -20,12 +20,12 @@
 
 python_pkgs = value_for_platform(
   ["debian","ubuntu"] => {
-    "default" => ["python","python-dev"]
+    "default" => ["python","python-dev","python3","python3-dev"]
   },
   ["centos","redhat","fedora"] => {
-    "default" => ["python26","python26-devel"]
+    "default" => ["python26","python26-devel","python3","python3-devel"]
   },
-  "default" => ["python","python-dev"]
+  "default" => ["python","python-dev","python3","python3-dev"]
 )
 
 python_pkgs.each do |pkg|


### PR DESCRIPTION
I need Python 3 to run my package's tests (it's a PHP package), but installing it with sudo and apt requires me to use the old infrastructure, which is quite a bit slower than the new Docker-based one (great job on that!).

Is there any chance that we could get Python 3 installed on all machines by default?

Not sure whether I did everything correctly, this is how far I got by walking through the source code. I'd be happy to accept any tips on how to improve this.