### PR TITLE
tune glibc memory allocation and make it better suited for Java processes

### DIFF
--- a/ci_environment/java/files/default/etc/profile.d/malloc_tune.sh
+++ b/ci_environment/java/files/default/etc/profile.d/malloc_tune.sh
@@ -1,0 +1,3 @@
+
+# tune glibc memory allocation
+export MALLOC_ARENA_MAX=2

--- a/ci_environment/java/files/default/etc/profile.d/malloc_tune.sh
+++ b/ci_environment/java/files/default/etc/profile.d/malloc_tune.sh
@@ -1,3 +1,8 @@
-
-# tune glibc memory allocation
+# tune glibc memory allocation, optimize for low fragmentation
+# limit the number of arenas
 export MALLOC_ARENA_MAX=2
+# disable dynamic mmap threshold, see M_MMAP_THRESHOLD in "man mallopt"
+export MALLOC_MMAP_THRESHOLD_=131072
+export MALLOC_TRIM_THRESHOLD_=131072
+export MALLOC_TOP_PAD_=131072
+export MALLOC_MMAP_MAX_=65536


### PR DESCRIPTION
- MALLOC_ARENA_MAX is explained in https://devcenter.heroku.com/articles/tuning-glibc-memory-behavior#what-value-to-choose-for-malloc_arena_max
or https://www.ibm.com/developerworks/community/blogs/kevgrig/entry/linux_glibc_2_10_rhel_6_malloc_may_show_excessive_virtual_memory_usage?lang=en

It saves memory especially on 64-bit JVM processes. Search for MALLOC_ARENA_MAX on Google, SO or Github to find others using it.

I'm not sure if this file `ci_environment/java/files/default/etc/profile.d/malloc_tune.sh` is the proper place for doing this setting.