### PR TITLE
Remove some custom Docker options and let the defaults shine

### DIFF
--- a/ci_environment/docker/files/default/etc/default/docker
+++ b/ci_environment/docker/files/default/etc/default/docker
@@ -1,1 +1,1 @@
-DOCKER_OPTS="--exec-driver=lxc --icc=false -H tcp://127.0.0.1:4243 -H unix:///var/run/docker.sock -g=/mnt/docker"
+DOCKER_OPTS="-H tcp://127.0.0.1:4243 -H unix:///var/run/docker.sock -g=/mnt/docker"


### PR DESCRIPTION
The rationale being that we don't have the same constraints here as we do in the Docker workers (since this is to get a Docker daemon inside other workers, not to literally run workers itself).