### PR TITLE
Update SDK Tools to v.24.1.2 and add SDK platform API 22

### DIFF
--- a/ci_environment/android-sdk/attributes/default.rb
+++ b/ci_environment/android-sdk/attributes/default.rb
@@ -5,8 +5,8 @@ default['android-sdk']['owner']          = node['travis_build_environment']['use
 default['android-sdk']['group']          = node['travis_build_environment']['group']
 default['android-sdk']['setup_root']     = nil  # ark defaults (/usr/local) is used if this attribute is not defined
 
-default['android-sdk']['version']        = '24.0.2'
-default['android-sdk']['checksum']       = 'c90d361406d5c1dc462342d931c5afda4c081d13708e9fb64c81a29b3d0bee8e'
+default['android-sdk']['version']        = '24.1.2'
+default['android-sdk']['checksum']       = '77dc2e98cf64a04d13d9554ec6ac8ad26a8b32d49119ae8af15348e715674f8e'
 default['android-sdk']['download_url']   = "http://dl.google.com/android/android-sdk_r#{node['android-sdk']['version']}-linux.tgz"
 
 #
@@ -21,7 +21,8 @@ default['android-sdk']['download_url']   = "http://dl.google.com/android/android
 # for it.
 #
 default['android-sdk']['components']     = %w(platform-tools
-                                              build-tools-21.1.2
+                                              build-tools-22.0.1
+                                              android-22
                                               android-21
                                               sys-img-armeabi-v7a-android-21
                                               android-20


### PR DESCRIPTION
Update SDK Tools version to 24.1.2
Update SDK Tools checksum (sha256sum)
Add new SDK platform, Android 5.1, API 22
Update build-tools version to 22.0.1

Google released a new SDK platform, Android 5.1, API 22
https://developer.android.com/tools/revisions/platforms.html

Google released a new version of SDK tools, further information here:
https://developer.android.com/sdk/index.html#Other

Download:
http://dl.google.com/android/android-sdk_r24.1.2-linux.tgz