### PR TITLE
node: update default to 0.12.1

### DIFF
--- a/vm_templates/common/node-js.yml
+++ b/vm_templates/common/node-js.yml
@@ -6,12 +6,12 @@ json:
       - 0.10.18
       - 0.10.37
       - 0.11.16
-      - 0.12.0
+      - 0.12.1
     aliases:
       "0.10": '0.1'
       0.11.16: node-head
       0.11.16: node-unstable
-    default: 0.12.0
+    default: 0.12.1
 recipes:
   - nodejs::multi
   - nodejs::iojs


### PR DESCRIPTION
0.12.1 was released on March 24, 2015, and is the latest stable version of Node