### PR TITLE
Allow to override /etc/mavenrc defaults

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -38,6 +38,9 @@
 
 - Install Python 3 (currently 3.2.3) on all images via Ubuntu package (Franz Liedke)
 
+- Improve `/etc/mavenrc` to export `M2_HOME` and `MAVEN_OPTS` only when these
+  environment variables are not already defined (Gilles Cornu)
+
 ### Production on 2015-02-03:
 
 - Update sbt-extras script to fix travis-ci/travis-ci#3140 (Gilles Cornu)

--- a/ci_environment/maven/CHANGELOG.md
+++ b/ci_environment/maven/CHANGELOG.md
@@ -3,6 +3,15 @@ maven Cookbook CHANGELOG
 This file is used to list changes made in each version of the maven cookbook.
 
 
+ADDITIONAL PATCH
+----------------
+
+The following change is not present in Chef Maven Cookbook up to version 1.3.0.
+
+- Allow to override /etc/mavenrc defaults
+  Fix https://github.com/opscode-cookbooks/maven/issues/44
+  Fix https://github.com/travis-ci/travis-ci/issues/1689
+
 v1.0.0
 ------
 ### Improvement

--- a/ci_environment/maven/templates/default/mavenrc.erb
+++ b/ci_environment/maven/templates/default/mavenrc.erb
@@ -1,3 +1,3 @@
-export M2_HOME=<%= node['maven']['m2_home'] %>
+[ -z "$M2_HOME" ] && export M2_HOME=<%= node['maven']['m2_home'] %>
 
-export MAVEN_OPTS="<%= node['maven']['mavenrc']['opts'] %>"
+[ -z "$MAVEN_OPTS" ] && export MAVEN_OPTS="<%= node['maven']['mavenrc']['opts'] %>"


### PR DESCRIPTION
With this change, it will be possible to set a custom value for `M2_HOME` and
`MAVEN_OPTS` environment variables via `.travis.yml`.

@BanzaiMan I did not push this change directly as it slightly modifies the Maven behaviour, and I prefer to get your approval. I don't consider it as a "breaking change", but some users might be surprised that their custom `M2_HOME` or `MAVEN_OPTS` variables suddenly become effective :wink:.

* Related to https://github.com/opscode-cookbooks/maven/issues/44
* Fix https://github.com/travis-ci/travis-ci/issues/1689