### PR TITLE
add builds for perl 5.22, removing 5.21

### DIFF
--- a/ci_environment/perlbrew/attributes/multi.rb
+++ b/ci_environment/perlbrew/attributes/multi.rb
@@ -4,7 +4,6 @@ default[:perlbrew] = {
                { :name => "5.20", :version => "perl-5.20.0"  },
                { :name => "5.20-extras", :version => "perl-5.20.0", :arguments => "-Duseshrplib -Duseithreads", :alias => '5.20-shrplib'},
                { :name => "5.18", :version => "perl-5.18.2" },
-               { :name => "5.18-extras", :version => "perl-5.18.2", :arguments => "-Duseshrplib -Duseithreads", :alias => '5.18-shrplib' },
                { :name => "5.16", :version => "perl-5.16.3" },
                { :name => "5.14", :version => "perl-5.14.4" },
                { :name => "5.12", :version => "perl-5.12.5" },

--- a/ci_environment/perlbrew/attributes/multi.rb
+++ b/ci_environment/perlbrew/attributes/multi.rb
@@ -1,5 +1,6 @@
 default[:perlbrew] = {
-  :perls   => [{ :name => "5.21", :version => "perl-5.21.0" },
+  :perls   => [{ :name => "5.22", :version => "perl-5.22.0"  },
+               { :name => "5.22-extras", :version => "perl-5.22.0", :arguments => "-Duseshrplib -Duseithreads", :alias => '5.22-shrplib'},
                { :name => "5.20", :version => "perl-5.20.0"  },
                { :name => "5.20-extras", :version => "perl-5.20.0", :arguments => "-Duseshrplib -Duseithreads", :alias => '5.20-shrplib'},
                { :name => "5.18", :version => "perl-5.18.2" },


### PR DESCRIPTION
There aren't any 5.23 releases yet, so not adding any dev release builds
currently.