### PR TITLE
use perl 5.8.8 rather than 5.8.9 for 5.8 testing

### DIFF
--- a/ci_environment/perlbrew/attributes/multi.rb
+++ b/ci_environment/perlbrew/attributes/multi.rb
@@ -8,6 +8,6 @@ default[:perlbrew] = {
                { :name => "5.14", :version => "perl-5.14.4" },
                { :name => "5.12", :version => "perl-5.12.5" },
                { :name => "5.10", :version => "perl-5.10.1" },
-               { :name => "5.8",  :version => "perl-5.8.9"  }],
+               { :name => "5.8",  :version => "perl-5.8.8"  }],
   :modules => %w(ExtUtils::MakeMaker Dist::Zilla Moose Test::Pod Test::Pod::Coverage Test::Exception Dist::Zilla::Plugin::Bootstrap::lib LWP Module::Install Test::Most)
 }


### PR DESCRIPTION
Perl 5.8.9 came out a year after 5.10.0 and is a weird amalgam of 5.8
and 5.10.  It never shipped with any OS, so users are very unlikely to
run into it in the wild.

Perl 5.8.8 is a much better representation of the 5.8 releases.