### PR TITLE
Update Android SDK Tools to v.24.3.4, build-tools to 23.0.0 and add android-23

### DIFF
--- a/ci_environment/android-sdk/attributes/default.rb
+++ b/ci_environment/android-sdk/attributes/default.rb
@@ -5,8 +5,8 @@ default['android-sdk']['owner']          = node['travis_build_environment']['use
 default['android-sdk']['group']          = node['travis_build_environment']['group']
 default['android-sdk']['setup_root']     = nil  # ark defaults (/usr/local) is used if this attribute is not defined
 
-default['android-sdk']['version']        = '24.1.2'
-default['android-sdk']['checksum']       = '77dc2e98cf64a04d13d9554ec6ac8ad26a8b32d49119ae8af15348e715674f8e'
+default['android-sdk']['version']        = '24.3.3'
+default['android-sdk']['checksum']       = 'a05023aaf149d40a0a848ad49d5c6b43ec730443efb89d1dfa584a132a642bdf'
 default['android-sdk']['download_url']   = "http://dl.google.com/android/android-sdk_r#{node['android-sdk']['version']}-linux.tgz"
 
 #

--- a/ci_environment/android-sdk/attributes/default.rb
+++ b/ci_environment/android-sdk/attributes/default.rb
@@ -5,8 +5,8 @@ default['android-sdk']['owner']          = node['travis_build_environment']['use
 default['android-sdk']['group']          = node['travis_build_environment']['group']
 default['android-sdk']['setup_root']     = nil  # ark defaults (/usr/local) is used if this attribute is not defined
 
-default['android-sdk']['version']        = '24.3.3'
-default['android-sdk']['checksum']       = 'a05023aaf149d40a0a848ad49d5c6b43ec730443efb89d1dfa584a132a642bdf'
+default['android-sdk']['version']        = '24.3.4'
+default['android-sdk']['checksum']       = '886412375d8fe6e49a1583e57a8a36a47943666da681701ba9ad1ab7236e83ea'
 default['android-sdk']['download_url']   = "http://dl.google.com/android/android-sdk_r#{node['android-sdk']['version']}-linux.tgz"
 
 #
@@ -21,9 +21,9 @@ default['android-sdk']['download_url']   = "http://dl.google.com/android/android
 # for it.
 #
 default['android-sdk']['components']     = %w(platform-tools
-                                              build-tools-22.0.1
+                                              build-tools-23.0.0
+                                              android-23
                                               android-22
-                                              sys-img-armeabi-v7a-android-22
                                               android-21
                                               sys-img-armeabi-v7a-android-21
                                               android-20

--- a/ci_environment/android-sdk/attributes/default.rb
+++ b/ci_environment/android-sdk/attributes/default.rb
@@ -23,6 +23,7 @@ default['android-sdk']['download_url']   = "http://dl.google.com/android/android
 default['android-sdk']['components']     = %w(platform-tools
                                               build-tools-22.0.1
                                               android-22
+                                              sys-img-armeabi-v7a-android-22
                                               android-21
                                               sys-img-armeabi-v7a-android-21
                                               android-20


### PR DESCRIPTION
- Update SDK Tools version to 24.3.4
- Update SDK Tools checksum (sha256sum)
- ~~Add ARM EABI v7a system image v.22~~
- Update Build Tools version to 23.0.0
- Add android-23 to support Android 6.0

Google released a new version of SDK tools, further information here:
https://developer.android.com/sdk/index.html#Other

Download:
http://dl.google.com/android/android-sdk_r24.3.4-linux.tgz

~~Added missing ARM sys.img for android-22 as @vmalyi request but I remember previous issue about disk space on docker images (I removed wear image to save 1Gb in the past) so please check it and delete a legacy one if needed.~~