### PR TITLE
Update SDK Tools to v.24.3.3 and add system image to v.22

### DIFF
--- a/ci_environment/android-sdk/attributes/default.rb
+++ b/ci_environment/android-sdk/attributes/default.rb
@@ -5,8 +5,8 @@ default['android-sdk']['owner']          = node['travis_build_environment']['use
 default['android-sdk']['group']          = node['travis_build_environment']['group']
 default['android-sdk']['setup_root']     = nil  # ark defaults (/usr/local) is used if this attribute is not defined
 
-default['android-sdk']['version']        = '24.1.2'
-default['android-sdk']['checksum']       = '77dc2e98cf64a04d13d9554ec6ac8ad26a8b32d49119ae8af15348e715674f8e'
+default['android-sdk']['version']        = '24.3.3'
+default['android-sdk']['checksum']       = 'cd4cab76c2e3d926b3495c26ec56c831ba77d0d0'
 default['android-sdk']['download_url']   = "http://dl.google.com/android/android-sdk_r#{node['android-sdk']['version']}-linux.tgz"
 
 #
@@ -23,6 +23,7 @@ default['android-sdk']['download_url']   = "http://dl.google.com/android/android
 default['android-sdk']['components']     = %w(platform-tools
                                               build-tools-22.0.1
                                               android-22
+                                              sys-img-armeabi-v7a-android-22
                                               android-21
                                               sys-img-armeabi-v7a-android-21
                                               android-20


### PR DESCRIPTION
- Update SDK Tools to v.24.3.3 (released on June 2015)
- Add ARM EABI v7a system image v.22

SDK Tools download URL: http://dl.google.com/android/android-sdk_r24.3.3-linux.tgz

Closes travis-ci/travis-ci#3958