### PR TITLE
Bump up sbt-extra to the latest

### DIFF
--- a/ci_environment/sbt-extras/attributes/default.rb
+++ b/ci_environment/sbt-extras/attributes/default.rb
@@ -7,7 +7,7 @@ else # usual base directory on unix systems:
   set['sbt-extras']['user_home_basedir']       = '/home'
 end
 
-default['sbt-extras']['download_url']          = 'https://raw.githubusercontent.com/paulp/sbt-extras/c117e2a7f28fafacbb7cb56490ff7896e5dc7d8f/sbt'
+default['sbt-extras']['download_url']          = 'https://raw.githubusercontent.com/paulp/sbt-extras/b9c8cb273d38e0d8da9211902a18018fe82aa14e/sbt'
 
 default['sbt-extras']['setup_dir']             = '/usr/local/bin'
 default['sbt-extras']['script_name']           = 'sbt'


### PR DESCRIPTION
The version of sbt-extra currently used by Travis CI downloads sbt launcher JAR from the *wrong URL*, which was fixed in paulp/sbt-extras#107.

This surfaced recently when Typesafe moved the underlying implementation of repo.typesafe.com from artifactoryonline.com to Bintray, and a release of new sbt version 0.13.9-RC1. 