### PR TITLE
Fix /etc/mavenrc

### DIFF
--- a/ci_environment/maven/templates/default/mavenrc.erb
+++ b/ci_environment/maven/templates/default/mavenrc.erb
@@ -1,3 +1,3 @@
-[ -z "$M2_HOME" ] && export M2_HOME=<%= node['maven']['m2_home'] %>
+[ -z "$M2_HOME" ] && export M2_HOME=${M2_HOME:-<%= node['maven']['m2_home'] %>}
 
 [ -z "$MAVEN_OPTS" ] && export MAVEN_OPTS="<%= node['maven']['mavenrc']['opts'] %>"


### PR DESCRIPTION
We should not override M2_HOME when it is already set.

The issue manifests as https://github.com/travis-ci/travis-ci/issues/4369,
which is being dealt with by 'travis-build' at the moment.

When this goes into effect, https://github.com/travis-ci/travis-build/commit/d38bb132121ff1d1aa3f1a68a033f2e918bb27a4
can be reverted.