### PR TITLE
Remove ubuntugis-stable PPA

### DIFF
--- a/ci_environment/postgresql/README.md
+++ b/ci_environment/postgresql/README.md
@@ -13,7 +13,6 @@ The **default** recipe of this Chef cookbook will:
 * Use RAMFS storage to reduce I/O impact (optional)
 * Tune some `postgresql.conf` parameters for performance optimization in a CI context (e.g. disable `fsync` data safety) (optional)
 * include **postgis** recipe to:
- * Add ubuntugis-stable PPA to backport libgdal1 (>= 1.9.0) on Ubuntu 12.04
  * Install the same PostGIS version from PGDG repository (e.g. 2.1) to all PostgreSQL instances (optional). Attention some combinations are not supported (e.g. PostGIS 2.1/PostgreSQL 8.4 or PostGIS 2.0/PostgreSQL 9.3)
 
 If you look for a more *"standard"* installation (e.g. for a productive database server), the [Opscode Community Cookbook](http://community.opscode.com/cookbooks/postgresql) and genuine [PostgreSQL Global Development Group (PGDG) packages](https://wiki.postgresql.org/wiki/Apt) may better fit your needs.

--- a/ci_environment/postgresql/recipes/postgis.rb
+++ b/ci_environment/postgresql/recipes/postgis.rb
@@ -1,19 +1,3 @@
-
-#
-# PostGIS packages are available in Ubuntu main repository as of 14.04 (Trusty)
-#
-if node['lsb']['codename'] == 'precise'
-  apt_repository 'ubuntugis-stable' do
-    uri          'http://ppa.launchpad.net/ubuntugis/ppa/ubuntu'
-    distribution node['lsb']['codename']
-    components   ['main']
-    key          '314DF160'
-    keyserver    'hkp://ha.pool.sks-keyservers.net'
-
-    action :add
-  end
-end
-
 package(
   (
     [node['postgresql']['default_version']] +


### PR DESCRIPTION
The `ubuntugis-stable` source conflicts with the `pgdg` source in that one uses `libgdal1`, the other `libgdal1h`, which causes many problems installing things that depend upon GDAL, see e.g. https://github.com/travis-ci/travis-ci/issues/2401.

According to the README in this directory, ubuntugis-stable was included to get libgdal >= 1.9. libgdal 1.9 is included in pgdg, so there is no longer a need for this PPA. Also, pgdg includes the postgresql postgis packages for 9.4 which it seems ubuntugis-stable does not; another reason not to use it.
