### PR TITLE
sysctl: Set kernel.shmmax immediately during running recipe

### DIFF
--- a/ci_environment/sysctl/recipes/default.rb
+++ b/ci_environment/sysctl/recipes/default.rb
@@ -12,5 +12,5 @@ template '/etc/sysctl.d/30-travis-shm.conf' do
   variables(
     kernel_shmmax: node['sysctl']['kernel_shmmax']
   )
-  notifies :run, 'execute[update sysctl travis-shm]'
+  notifies :run, 'execute[update sysctl travis-shm]', :immediately
 end


### PR DESCRIPTION
Postgres service needs the kernel.shmmax set to sufficient value before
it is started. However the execute resource that is setting this value
gets run upon notification that gets delayed (queued up) by default to
the end of the whole chef-client run. So make sure the notification for
the execute resource gets delivered immediately so that kernel.shmmax is
set before postgres is run.

Problem experienced (and solution verified) with [BanzaiMan/travis-packer](http://github.com/BanzaiMan/travis-packer)
## Before:

```
# execute[update sysctl travis-shm] resource is registered, but not run (that is OK)
virtualbox-iso: [2015-07-28T16:04:46+00:00] INFO: Processing execute[update sysctl travis-shm] action nothing (sysctl::default line 1)
virtualbox-iso: [2015-07-28T16:04:46+00:00] INFO: Processing template[/etc/sysctl.d/30-travis-shm.conf] action create (sysctl::default line 7)
virtualbox-iso: [2015-07-28T16:04:46+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] created file /etc/sysctl.d/30-travis-shm.conf
virtualbox-iso: [2015-07-28T16:04:46+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] updated file contents /etc/sysctl.d/30-travis-shm.conf
virtualbox-iso: [2015-07-28T16:04:46+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] owner changed to 0
virtualbox-iso: [2015-07-28T16:04:46+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] group changed to 0
virtualbox-iso: [2015-07-28T16:04:46+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] mode changed to 644
# execute[update sysctl travis-shm] resource is notified, but the notification is delayed, so nothing is run here and we continue with openssh and other recipes
virtualbox-iso: [2015-07-28T16:04:46+00:00] INFO: Processing apt_package[openssh-server] action install (openssh::default line 20)
...
# postgres expects the kernel.shmmax to already be set, but it is not, so it fails
virtualbox-iso: [2015-07-28T16:45:07+00:00] INFO: Processing service[postgresql] action enable (postgresql::default line 39)
virtualbox-iso: [2015-07-28T16:45:07+00:00] INFO: Processing service[postgresql] action restart (postgresql::default line 39)
virtualbox-iso:
virtualbox-iso: ================================================================================
virtualbox-iso: Error executing action `restart` on resource 'service[postgresql]'
virtualbox-iso: ================================================================================
...
virtualbox-iso: * The PostgreSQL server failed to start. Please check the log output:
virtualbox-iso: 2015-07-28 16:45:09 UTC FATAL:  could not create shared memory segment: Invalid argument
virtualbox-iso: 2015-07-28 16:45:09 UTC DETAIL:  Failed system call was shmget(key=5432001, size=40140800, 03600).
...
# after the failure, the delayed notifications get run, first of which is our most desired 'update sysctl travis-shm', but that is too late
virtualbox-iso: [2015-07-28T16:45:09+00:00] INFO: Running queued delayed notifications before re-raising exception
virtualbox-iso: [2015-07-28T16:45:09+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] sending run action to execute[update sysctl travis-shm] (delayed)
virtualbox-iso: [2015-07-28T16:45:09+00:00] INFO: Processing execute[update sysctl travis-shm] action run (sysctl::default line 1)
virtualbox-iso: [2015-07-28T16:45:09+00:00] INFO: execute[update sysctl travis-shm] ran successfully
```
## After:

```
# execute resource is registered, but not run (that is OK)
virtualbox-iso: [2015-07-28T17:52:44+00:00] INFO: Processing execute[update sysctl travis-shm] action nothing (sysctl::default line 1)
virtualbox-iso: [2015-07-28T17:52:44+00:00] INFO: Processing template[/etc/sysctl.d/30-travis-shm.conf] action create (sysctl::default line 7)
virtualbox-iso: [2015-07-28T17:52:44+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] created file /etc/sysctl.d/30-travis-shm.conf
virtualbox-iso: [2015-07-28T17:52:44+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] updated file contents /etc/sysctl.d/30-travis-shm.conf
virtualbox-iso: [2015-07-28T17:52:44+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] owner changed to 0
virtualbox-iso: [2015-07-28T17:52:44+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] group changed to 0
virtualbox-iso: [2015-07-28T17:52:44+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] mode changed to 644
# execute resource is notified and the notification is delivered immediately, so the action (setting kernel.shmmax) is run immediately
virtualbox-iso: [2015-07-28T17:52:44+00:00] INFO: template[/etc/sysctl.d/30-travis-shm.conf] sending run action to execute[update sysctl travis-shm] (immediate)
virtualbox-iso: [2015-07-28T17:52:44+00:00] INFO: Processing execute[update sysctl travis-shm] action run (sysctl::default line 1)
virtualbox-iso: [2015-07-28T17:52:44+00:00] INFO: execute[update sysctl travis-shm] ran successfully
virtualbox-iso: [2015-07-28T17:52:44+00:00] INFO: Processing apt_package[openssh-server] action install (openssh::default line 20)
...
# postgres starts fine
virtualbox-iso: [2015-07-28T20:30:08+00:00] INFO: Processing service[postgresql] action enable (postgresql::default line 39)
virtualbox-iso: [2015-07-28T20:30:08+00:00] INFO: Processing service[postgresql] action restart (postgresql::default line 39)
virtualbox-iso: [2015-07-28T20:30:11+00:00] INFO: service[postgresql] restarted
```
