### PR TITLE
Updated HHVM to 3.6.5

### DIFF
--- a/ci_environment/hhvm/attributes/default.rb
+++ b/ci_environment/hhvm/attributes/default.rb
@@ -1,5 +1,5 @@
 default["hhvm"]["package"]["name"] = "hhvm"
-default["hhvm"]["package"]["version"] = "3.5.0~precise"
+default["hhvm"]["package"]["version"] = "3.6.5~precise"
 default["hhvm"]["package"]["disabled"] = false
 
 default["hhvm"]["package"]["url"] = "https://s3.amazonaws.com/travis-php-packages/hhvm_2.3.0_amd64.deb"


### PR DESCRIPTION
3.6.x is the last release available on this version of ubuntu.