### PR TITLE
key_buffer has been key_buffer_size since 5.0

### DIFF
--- a/ci_environment/mysql/attributes/server.rb
+++ b/ci_environment/mysql/attributes/server.rb
@@ -47,6 +47,7 @@ default['mysql']['ci_user_password']       = ""
 default['mysql']['allow_remote_root']               = false
 default['mysql']['tunable']['back_log']             = "128"
 default['mysql']['tunable']['key_buffer']           = "256M"
+default['mysql']['tunable']['key_buffer_size']      = "256M"
 default['mysql']['tunable']['max_allowed_packet']   = "16M"
 default['mysql']['tunable']['max_connections']      = "800"
 default['mysql']['tunable']['max_heap_table_size']  = "32M"

--- a/ci_environment/mysql/metadata.rb
+++ b/ci_environment/mysql/metadata.rb
@@ -42,7 +42,11 @@ attribute "mysql/tunable",
   :type => "hash"
 
 attribute "mysql/tunable/key_buffer",
-  :display_name => "MySQL Tuntable Key Buffer",
+  :display_name => "MySQL Tunable Key Buffer for MySQL < 5.0.0",
+  :default => "250M"
+
+attribute "mysql/tunable/key_buffer_size",
+  :display_name => "MySQL Tunable Key Buffer for MySQL >= 5.0.0",
   :default => "250M"
 
 attribute "mysql/tunable/max_connections",

--- a/ci_environment/mysql/templates/default/my.cnf.erb
+++ b/ci_environment/mysql/templates/default/my.cnf.erb
@@ -66,7 +66,7 @@ innodb_large_prefix
 #
 # * Fine Tuning
 #
-key_buffer              = <%= node['mysql']['tunable']['key_buffer'] %>
+key_buffer_size         = <%= node['mysql']['tunable']['key_buffer'] %>
 max_allowed_packet      = 16M
 thread_stack            = 256K
 thread_cache_size       = 8

--- a/ci_environment/mysql/templates/default/ramfs/my.cnf.erb
+++ b/ci_environment/mysql/templates/default/ramfs/my.cnf.erb
@@ -60,7 +60,7 @@ innodb_large_prefix
 #
 # * Fine Tuning
 #
-key_buffer              = <%= node['mysql']['tunable']['key_buffer'] %>
+key_buffer_size         = <%= node['mysql']['tunable']['key_buffer'] %>
 max_allowed_packet      = 16M
 thread_stack            = 256K
 thread_cache_size       = 8


### PR DESCRIPTION
also fixes typo.

Fixing this before later mysql/mariadb version drop the old syntax.
