### PR TITLE
Move mysql config to conf_dir/conf.d/travis.cnf

### DIFF
--- a/ci_environment/mysql/recipes/server.rb
+++ b/ci_environment/mysql/recipes/server.rb
@@ -75,7 +75,7 @@ service "mysql" do
   end
 end
 
-template "#{node['mysql']['conf_dir']}/my.cnf" do
+template "#{node['mysql']['conf_dir']}/conf.d/travis.cnf" do
   source "my.cnf.erb"
   owner "root"
   group "root"

--- a/ci_environment/mysql/recipes/server_deb.rb
+++ b/ci_environment/mysql/recipes/server_deb.rb
@@ -57,6 +57,11 @@ if platform?(%w{debian ubuntu})
     recursive true
   end
 
+  directory "#{node['mysql']['conf_dir']}/conf.d" do
+    action :create
+    recursive true
+  end
+
   template "#{node['mysql']['conf_dir']}/debian.cnf" do
     source "debian.cnf.erb"
     owner "root"
@@ -88,7 +93,7 @@ service "mysql" do
   end
 end
 
-template "#{node['mysql']['conf_dir']}/my.cnf" do
+template "#{node['mysql']['conf_dir']}/conf.d/travis.cnf" do
   source "my.cnf.erb"
   owner "root"
   group "root"

--- a/ci_environment/mysql/recipes/server_on_ramfs.rb
+++ b/ci_environment/mysql/recipes/server_on_ramfs.rb
@@ -61,7 +61,7 @@ bash "cp -R #{node['mysql']['data_dir']} #{node[:ramfs][:dir]}/mysql" do
 end
 
 # Now install a custom my.cnf that will use a ramfs directory for datadir.
-template "#{node['mysql']['conf_dir']}/my.cnf" do
+template "#{node['mysql']['conf_dir']}/conf.d/travis.cnf" do
   source "ramfs/my.cnf.erb"
 
   owner "root"


### PR DESCRIPTION
With mysql and mariadb addons forcing the overide of configuration in
their package installs, this patch moves the mysql configuration to a
subdirectory included by both packages.

By doing so it keep the configuration consistent beween mariadb and
mysql versions.
