### PR TITLE
Fix phpunit on php 5.3-5.5

### DIFF
--- a/ci_environment/php/recipes/hhvm.rb
+++ b/ci_environment/php/recipes/hhvm.rb
@@ -35,7 +35,7 @@ end
 
 # Install phpunit
 remote_file "#{hhvm_path}/bin/phpunit" do
-  source "https://phar.phpunit.de/phpunit.phar"
+  source "https://phar.phpunit.de/phpunit-old.phar"
   owner  node.travis_build_environment.user
   group  node.travis_build_environment.group
   mode   0755

--- a/ci_environment/phpunit/recipes/default.rb
+++ b/ci_environment/phpunit/recipes/default.rb
@@ -5,7 +5,7 @@ phpenv_path = File.join(node.travis_build_environment.home, ".phpenv")
 node[:php][:multi][:versions].each do |php_version|
   bin_path = "#{phpenv_path}/versions/#{php_version}/bin"
   remote_file "#{bin_path}/phpunit" do
-    source "https://phar.phpunit.de/phpunit.phar"
+    source "https://phar.phpunit.de/phpunit-old.phar"
     owner  node.travis_build_environment.user
     group  node.travis_build_environment.group
     mode   0755


### PR DESCRIPTION
PHPUnit 5 requires php 5.6+, so we'll need to use phpunit 4.

Also note that phpunit 4 doesn't technically support php 7, so we might want to change the logic here.