### PR TITLE
Install PostGIS for PostgreSQL 9.4

### DIFF
--- a/cookbooks/postgresql/recipes/postgis.rb
+++ b/cookbooks/postgresql/recipes/postgis.rb
@@ -18,8 +18,5 @@ end
 # At the moment, the same PostGIS *single* version is installed for all PostgreSQL instances
 #
 ([node['postgresql']['default_version']] + node['postgresql']['alternate_versions']).each do |pg_version|
-  # For now, skip 9.4 Beta, which is not integrated yet in ubuntugis stable PPA
-  if pg_version != '9.4'
-    package "postgresql-#{pg_version}-postgis-#{node['postgresql']['postgis_version']}"
-  end
+  package "postgresql-#{pg_version}-postgis-#{node['postgresql']['postgis_version']}"
 end


### PR DESCRIPTION
Fix travis-ci/travis-ci#5178

Note: the "9.4 beta" skipping condition was already removed in `precise-stable` [branch](https://github.com/travis-ci/travis-cookbooks/blob/precise-stable/ci_environment/postgresql/recipes/postgis.rb#L20-L22)