### PR TITLE
Fix outdated or missing attributes for travis_ci_mega installation

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -62,7 +62,8 @@ default['travis_build_environment']['rvmrc_env'] = {
   'rvm_silence_path_mismatch_check_flag' => '1',
   'rvm_user_install_flag' => '1',
   'rvm_with_default_gems' => 'rake bundler',
-  'rvm_without_gems' => 'rubygems-bundler'
+  'rvm_without_gems' => 'rubygems-bundler',
+  'rvm_autolibs_flag' => 'read-fail'
 }
 default['travis_build_environment']['golang_libraries'] = %w(
   golang.org/x/tools/cmd/cover

--- a/cookbooks/travis_system_info/recipes/default.rb
+++ b/cookbooks/travis_system_info/recipes/default.rb
@@ -15,7 +15,7 @@ remote_file local_gem do
 end
 
 gem_package 'system-info' do
-  gem_binary '/opt/chef/embedded/bin/gem'
+  gem_binary '/opt/chefdk/embedded/bin/gem'
   source local_gem
 end
 


### PR DESCRIPTION
This stops rvm from prompting for a password when running `apt-get update`