### PR TITLE
Don't install gometalinter on Go 1.4

### DIFF
--- a/cookbooks/travis_build_environment/recipes/ci_user.rb
+++ b/cookbooks/travis_build_environment/recipes/ci_user.rb
@@ -129,7 +129,7 @@ gimme_versions += [gimme_default_version] unless gimme_default_version.empty?
 
 gimme_versions.each do |version|
   version = version.sub('go', '')
-  next if version < '1.4'
+  next if version < '1.5'
 
   Array(node['travis_build_environment']['golang_libraries']).each do |lib|
     bash "install #{lib} for go #{version}" do


### PR DESCRIPTION
Several of the linters now require Go 1.5 and above. Only the last installed version will be used, since each version will overwrite the previous one, so as long as we install a Go version above 1.4, this shouldn't have any effect on the end result.