### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Travis internal machines.
 
 The wrapper cookbooks that compose together the cookbooks found here live over
 in the [Travis CI Infrastructure Packer
-Templates](https://github.com/travis-infrastructure/packer-templates)
+Templates](https://github.com/travis-ci/packer-templates)
 repository.
 
 ## Developing Cookbooks


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/travis-infrastructure/packer-templates | https://github.com/travis-ci/packer-templates 
