### PR TITLE
The cmake-extras package is not available for Ubuntu trusty

### DIFF
--- a/cookbooks/travis_cmake/recipes/default.rb
+++ b/cookbooks/travis_cmake/recipes/default.rb
@@ -29,4 +29,4 @@ apt_repository 'cmake' do
   distribution node['lsb']['codename']
 end
 
-package %w(cmake cmake-extras)
+package %w(cmake)


### PR DESCRIPTION
The cmake-extras package is included in Canonical repositories [from Vivid only](http://packages.ubuntu.com/search?keywords=cmake-extras&searchon=names).

It is not part of [Nathan Osman's repository](https://launchpad.net/~george-edison55/+archive/ubuntu/cmake-3.x) either.