### PR TITLE
Lock rubocop to 0.34.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,7 @@ addons:
     packages:
     - chefdk
 
+before_install:
+  - gem install rubocop --version=0.34.2
+
 script: ./runtests


### PR DESCRIPTION
Newer versions change so builds start failing.