### PR TITLE
update gradle to version 2.13 from 2.7

### DIFF
--- a/cookbooks/gradle/attributes/default.rb
+++ b/cookbooks/gradle/attributes/default.rb
@@ -1,6 +1,6 @@
-gradle_version = '2.7'
+gradle_version = '2.13'
 
 default['gradle']['version'] = gradle_version
 default['gradle']['installation_dir'] = '/usr/local/gradle'
 default['gradle']['url'] = "https://downloads.gradle.org/distributions/gradle-#{gradle_version}-bin.zip"
-default['gradle']['checksum'] = 'cde43b90945b5304c43ee36e58aab4cc6fb3a3d5f9bd9449bb1709a68371cb06'
+default['gradle']['checksum'] = '0f665ec6a5a67865faf7ba0d825afb19c26705ea0597cec80dd191b0f2cbb664'


### PR DESCRIPTION
A lot has changed in gradle from 2.7. This pull request is to update to the latest version so that new features can be used by default.