### PR TITLE
Install system-info local gem manually

### DIFF
--- a/ci_environment/travis_system_info/recipes/default.rb
+++ b/ci_environment/travis_system_info/recipes/default.rb
@@ -14,10 +14,7 @@ remote_file local_gem do
   checksum node['travis_system_info']['gem_sha256sum']
 end
 
-gem_package 'system-info' do
-  gem_binary '/opt/chef/embedded/bin/gem'
-  source local_gem
-end
+execute "/opt/chef/embedded/bin/gem install -b #{local_gem.inspect}"
 
 execute "rm -rf #{node['travis_system_info']['dest_dir']}"
 


### PR DESCRIPTION
as chef 12.10+ automatically adds `--local` when using `gem_package` with a
local source, which is a design decision ... that doesn't work for this case.