### PR TITLE
Queue up system-info report for the end

### DIFF
--- a/cookbooks/travis_system_info/recipes/default.rb
+++ b/cookbooks/travis_system_info/recipes/default.rb
@@ -38,4 +38,10 @@ ruby_block 'generate system-info report' do
     exec.environment('HOME' => node['travis_build_environment']['home'])
     exec.run_action(:run)
   end
+
+  action :nothing
+end
+
+log 'system-info is coming for you' do
+  notifies :run, 'ruby_block[generate system-info report]', :delayed
 end


### PR DESCRIPTION
so that it hopefully runs *after* other delayed actions

(appears to work https://gist.github.com/meatballhat/f1b0102aabb7d3fc82e093fbeb438dd6)