### PR TITLE
Create travis_docker::binary recipe

### DIFF
--- a/cookbooks/travis_docker/attributes/default.rb
+++ b/cookbooks/travis_docker/attributes/default.rb
@@ -1,4 +1,4 @@
-default['travis_docker']['version'] = '1.10.3-0~trusty'
+default['travis_docker']['version'] = '1.12.0-0~trusty'
 default['travis_docker']['users'] = %w(travis)
 default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.8.0/docker-compose-Linux-x86_64'
 default['travis_docker']['compose']['sha256sum'] = 'ebc6ab9ed9c971af7efec074cff7752593559496d0d5f7afb6bfd0e0310961ff'

--- a/cookbooks/travis_docker/attributes/default.rb
+++ b/cookbooks/travis_docker/attributes/default.rb
@@ -6,7 +6,7 @@ default['travis_docker']['update_grub'] = true
 default['travis_docker']['binary']['url'] = 'https://get.docker.com/builds/Linux/x86_64/docker-1.12.0.tgz'
 default['travis_docker']['binary']['version'] = '1.12.0'
 default['travis_docker']['binary']['checksum'] = '3dd07f65ea4a7b4c8829f311ab0213bca9ac551b5b24706f3e79a97e22097f8b'
-default['travis_docker']['binary']['has_binaries'] = %w(
+default['travis_docker']['binary']['binaries'] = %w(
   docker
   docker-containerd
   docker-containerd-ctr

--- a/cookbooks/travis_docker/attributes/default.rb
+++ b/cookbooks/travis_docker/attributes/default.rb
@@ -3,3 +3,15 @@ default['travis_docker']['users'] = %w(travis)
 default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.6.2/docker-compose-Linux-x86_64'
 default['travis_docker']['compose']['sha256sum'] = '7c453a3e52fb97bba34cf404f7f7e7913c86e2322d612e00c71bd1588587c91e'
 default['travis_docker']['update_grub'] = true
+default['travis_docker']['binary']['url'] = 'https://get.docker.com/builds/Linux/x86_64/docker-1.12.0.tgz'
+default['travis_docker']['binary']['version'] = '1.12.0'
+default['travis_docker']['binary']['checksum'] = '3dd07f65ea4a7b4c8829f311ab0213bca9ac551b5b24706f3e79a97e22097f8b'
+default['travis_docker']['binary']['has_binaries'] = %w(
+  docker
+  docker-containerd
+  docker-containerd-ctr
+  docker-containerd-shim
+  docker-proxy
+  docker-runc
+  dockerd
+)

--- a/cookbooks/travis_docker/attributes/default.rb
+++ b/cookbooks/travis_docker/attributes/default.rb
@@ -1,7 +1,7 @@
 default['travis_docker']['version'] = '1.10.3-0~trusty'
 default['travis_docker']['users'] = %w(travis)
-default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.6.2/docker-compose-Linux-x86_64'
-default['travis_docker']['compose']['sha256sum'] = '7c453a3e52fb97bba34cf404f7f7e7913c86e2322d612e00c71bd1588587c91e'
+default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.8.0/docker-compose-Linux-x86_64'
+default['travis_docker']['compose']['sha256sum'] = 'ebc6ab9ed9c971af7efec074cff7752593559496d0d5f7afb6bfd0e0310961ff'
 default['travis_docker']['update_grub'] = true
 default['travis_docker']['binary']['url'] = 'https://get.docker.com/builds/Linux/x86_64/docker-1.12.0.tgz'
 default['travis_docker']['binary']['version'] = '1.12.0'

--- a/cookbooks/travis_docker/metadata.rb
+++ b/cookbooks/travis_docker/metadata.rb
@@ -9,3 +9,4 @@ long_description 'No really, install docker!'
 supports 'ubuntu', '>= 14.04'
 
 depends 'apt'
+depends 'ark'

--- a/cookbooks/travis_docker/recipes/binary.rb
+++ b/cookbooks/travis_docker/recipes/binary.rb
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-ark 'docker-binary' do
+ark 'docker' do
   url node['travis_docker']['binary']['url']
   version node['travis_docker']['binary']['version']
   checksum node['travis_docker']['binary']['checksum']

--- a/cookbooks/travis_docker/recipes/binary.rb
+++ b/cookbooks/travis_docker/recipes/binary.rb
@@ -1,0 +1,29 @@
+# Cookbook Name:: travis_docker
+# Recipe:: binary
+# Copyright 2016, Travis CI GmbH <contact+travis-cookbooks@travis-ci.org>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+ark 'docker-binary' do
+  url node['travis_docker']['binary']['url']
+  version node['travis_docker']['binary']['version']
+  checksum node['travis_docker']['binary']['checksum']
+  strip_components 1
+  has_binaries node['travis_docker']['binary']['binaries']
+end


### PR DESCRIPTION
to install the docker binaries and *not* set up the docker service.  This means we can offer the docker client et al within a docker container without having to modify or disable the docker service in combination with `apt-get install docker-engine`.