### PR TITLE
Ensure all apt_repository resources have retries

### DIFF
--- a/cookbooks/cassandra/recipes/datastax.rb
+++ b/cookbooks/cassandra/recipes/datastax.rb
@@ -27,7 +27,8 @@ apt_repository 'datastax' do
   distribution 'stable'
   components ['main']
   key 'http://debian.datastax.com/debian/repo_key'
-
+  retries 2
+  retry_delay 30
   action :add
 end
 

--- a/cookbooks/cassandra/recipes/package.rb
+++ b/cookbooks/cassandra/recipes/package.rb
@@ -27,7 +27,8 @@ apt_repository 'datastax' do
   distribution 'stable'
   components ['main']
   key 'http://debian.datastax.com/debian/repo_key'
-
+  retries 2
+  retry_delay 30
   action :add
 end
 

--- a/cookbooks/couchdb/recipes/ubuntu_ppa.rb
+++ b/cookbooks/couchdb/recipes/ubuntu_ppa.rb
@@ -21,6 +21,7 @@ apt_repository 'couchdb-ppa' do
   components ['main']
   key 'C17EAB57'
   keyserver 'keyserver.ubuntu.com'
-
+  retries 2
+  retry_delay 30
   action :add
 end

--- a/cookbooks/duo_unix/recipes/default.rb
+++ b/cookbooks/duo_unix/recipes/default.rb
@@ -12,6 +12,8 @@ apt_repository 'duosecurity' do
   distribution 'trusty'
   components ['main']
   key 'duosecurity.gpg'
+  retries 2
+  retry_delay 30
 end
 
 package 'duo-unix' do

--- a/cookbooks/gcc/recipes/ppa.rb
+++ b/cookbooks/gcc/recipes/ppa.rb
@@ -26,6 +26,8 @@ apt_repository 'ubuntu-toolchain-r-test' do
   components ['main']
   key 'BA9EF27F'
   keyserver 'keyserver.ubuntu.com'
+  retries 2
+  retry_delay 30
   action :add
 end
 

--- a/cookbooks/google-chrome/recipes/default.rb
+++ b/cookbooks/google-chrome/recipes/default.rb
@@ -26,6 +26,8 @@ apt_repository 'google-chrome' do
   distribution ''
   components %w(stable main)
   key 'https://dl-ssl.google.com/linux/linux_signing_key.pub'
+  retries 2
+  retry_delay 30
 end
 
 package 'google-chrome-stable'

--- a/cookbooks/haskell/recipes/multi.rb
+++ b/cookbooks/haskell/recipes/multi.rb
@@ -83,6 +83,8 @@ apt_repository 'cabal-install-ppa' do
   components ['main']
   key '9DF71E85'
   keyserver 'keyserver.ubuntu.com'
+  retries 2
+  retry_delay 30
   action :add
   only_if { node['lsb']['codename'] == 'precise' }
 end

--- a/cookbooks/postgresql/recipes/pgdg.rb
+++ b/cookbooks/postgresql/recipes/pgdg.rb
@@ -8,6 +8,7 @@ apt_repository 'pgdg' do
   # See https://wiki.postgresql.org/wiki/Apt/FAQ#I_want_to_try_the_beta_version_of_the_next_PostgreSQL_release
   components ['main']
   key 'http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc'
-
+  retries 2
+  retry_delay 30
   action :add
 end

--- a/cookbooks/postgresql/recipes/postgis.rb
+++ b/cookbooks/postgresql/recipes/postgis.rb
@@ -9,7 +9,8 @@ if node['lsb']['codename'] == 'precise'
     components ['main']
     key '314DF160'
     keyserver 'keyserver.ubuntu.com'
-
+    retries 2
+    retry_delay 30
     action :add
   end
 end

--- a/cookbooks/pypy/recipes/ppa.rb
+++ b/cookbooks/pypy/recipes/ppa.rb
@@ -26,7 +26,8 @@ apt_repository 'pypy' do
   components ['main']
   key '68854915'
   keyserver 'keyserver.ubuntu.com'
-
+  retries 2
+  retry_delay 30
   action :add
 end
 

--- a/cookbooks/redis/recipes/default.rb
+++ b/cookbooks/redis/recipes/default.rb
@@ -27,7 +27,8 @@ apt_repository 'rwky-redis' do
   components ['main']
   key '5862E31D'
   keyserver 'keyserver.ubuntu.com'
-
+  retries 2
+  retry_delay 30
   action :add
 end
 

--- a/cookbooks/riak/recipes/default.rb
+++ b/cookbooks/riak/recipes/default.rb
@@ -8,7 +8,8 @@ apt_repository 'basho-riak' do
   distribution node['lsb']['codename']
   components ['main']
   key 'https://packagecloud.io/gpg.key'
-
+  retries 2
+  retry_delay 30
   action :add
 end
 

--- a/cookbooks/travis_docker/recipes/package.rb
+++ b/cookbooks/travis_docker/recipes/package.rb
@@ -25,6 +25,8 @@ apt_repository 'docker' do
   distribution 'ubuntu-trusty'
   components ['main']
   key 'https://apt.dockerproject.org/gpg'
+  retries 2
+  retry_delay 30
   action :add
 end
 

--- a/cookbooks/travis_git/recipes/ppa.rb
+++ b/cookbooks/travis_git/recipes/ppa.rb
@@ -18,6 +18,8 @@
 apt_repository 'git-ppa' do
   uri 'ppa:git-core/ppa'
   distribution node['lsb']['codename']
+  retries 2
+  retry_delay 30
 end
 
 package 'git'

--- a/cookbooks/travis_java/recipes/openjdk-r.rb
+++ b/cookbooks/travis_java/recipes/openjdk-r.rb
@@ -4,6 +4,7 @@ apt_repository 'openjdk-r-java-ppa' do
   components ['main']
   key '86F44E2A'
   keyserver 'keyserver.ubuntu.com'
-
+  retries 2
+  retry_delay 30
   action :add
 end

--- a/cookbooks/travis_java/recipes/webupd8.rb
+++ b/cookbooks/travis_java/recipes/webupd8.rb
@@ -9,7 +9,8 @@ apt_repository 'webupd8team-java-ppa' do
   components ['main']
   key 'EEA14886'
   keyserver 'keyserver.ubuntu.com'
-
+  retries 2
+  retry_delay 30
   action :add
 end
 

--- a/cookbooks/virtualbox/recipes/default.rb
+++ b/cookbooks/virtualbox/recipes/default.rb
@@ -4,8 +4,10 @@ apt_repository 'oracle-virtualbox' do
   uri 'http://download.virtualbox.org/virtualbox/debian'
   distribution node['lsb']['codename']
   components %w(contrib)
-  action :add
   key 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc'
+  retries 2
+  retry_delay 30
+  action :add
 end
 
 package 'virtualbox-4.1' do


### PR DESCRIPTION
since network interruptions related to this resource type are a leading cause of
build failures