### PR TITLE
Set 127.0.1.1 to resolve for only `ip4-loopback`

### DIFF
--- a/cookbooks/travis_build_environment/templates/default/etc/cloud/templates/hosts.tmpl.erb
+++ b/cookbooks/travis_build_environment/templates/default/etc/cloud/templates/hosts.tmpl.erb
@@ -2,10 +2,9 @@
 \## cookbook:: travis_build_environment
 \##     file:: templates/default/etc/cloud/templates/hosts.tmpl.erb
 
-<% %w(127.0.0.1 127.0.1.1).each do |addr| %>
-<%= addr %> $hostname $fqdn
-<%= addr %> localhost <%= @hostname %> nettuno travis vagrant
-<% end %>
+127.0.0.1 $hostname $fqdn
+127.0.0.1 localhost <%= @hostname %> nettuno travis vagrant
+127.0.1.1 ip4-loopback
 
 <% unless node['travis_build_environment']['sysctl_disable_ipv6'] %>
 <% if node['ip6address'] %>

--- a/cookbooks/travis_build_environment/templates/default/etc/hosts.erb
+++ b/cookbooks/travis_build_environment/templates/default/etc/hosts.erb
@@ -1,8 +1,7 @@
 # Managed by Chef on <%= node.name %> :heart:
 
-<% %w(127.0.0.1 127.0.1.1).each do |addr| %>
-<%= addr %> localhost <%= @hostname %> nettuno travis vagrant
-<% end %>
+127.0.0.1 localhost <%= @hostname %> nettuno travis vagrant
+127.0.1.1 ip4-loopback
 <% unless node['travis_build_environment']['sysctl_disable_ipv6'] %>
 <% if node['ip6address'] %>
 <% %W(#{node['ip6address']} ::1).each do |addr| %>


### PR DESCRIPTION
as resolving `localhost` to `127.0.1.1` causes *bad things* in certain situations.  Yes, it can happen.

See https://www.traviscistatus.com/incidents/11hp8bhkrkn7

## moar info

When there are multiple matches for a host name in `/etc/hosts`, Ruby's `Resolv::Defaultresolver.getaddress` returns the last one (https://github.com/ruby/ruby/blob/bfe6bd0f72a58196969ad7dbdf409fe4573c5eea/lib/resolv.rb#L211).

This is bad news for some software, notably mongoid, as it sends connections to an address to which MongoDB is not bound.  We avoid this problem by not assigning multiple addresses to
our host names.  We still need 127.0.1.1 (See http://serverfault.com/a/363098), so
we assign a single name to this numeric IP address.