### PR TITLE
Adjusting hosts entries for `127.0.[01].1`

### DIFF
--- a/cookbooks/travis_build_environment/templates/default/etc/cloud/templates/hosts.tmpl.erb
+++ b/cookbooks/travis_build_environment/templates/default/etc/cloud/templates/hosts.tmpl.erb
@@ -2,8 +2,8 @@
 \## cookbook:: travis_build_environment
 \##     file:: templates/default/etc/cloud/templates/hosts.tmpl.erb
 
-127.0.0.1 localhost <%= @hostname %> nettuno travis vagrant $hostname $fqdn
-127.0.1.1 ip4-loopback
+127.0.0.1 localhost nettuno travis vagrant
+127.0.1.1 $hostname $fqdn ip4-loopback <%= @hostname %>
 
 <% unless node['travis_build_environment']['sysctl_disable_ipv6'] %>
 <% if node['ip6address'] %>

--- a/cookbooks/travis_build_environment/templates/default/etc/hosts.erb
+++ b/cookbooks/travis_build_environment/templates/default/etc/hosts.erb
@@ -1,7 +1,7 @@
 # Managed by Chef on <%= node.name %> :heart:
 
-127.0.0.1 localhost <%= @hostname %> nettuno travis vagrant
-127.0.1.1 ip4-loopback
+127.0.0.1 localhost nettuno travis vagrant
+127.0.1.1 ip4-loopback <%= @hostname %>
 <% unless node['travis_build_environment']['sysctl_disable_ipv6'] %>
 <% if node['ip6address'] %>
 <% %W(#{node['ip6address']} ::1).each do |addr| %>


### PR DESCRIPTION
such that there is (still) only one line for `127.0.0.1` and the `@hostname`
template var as well as the cloud-init vars point to `127.0.1.1`.