### PR TITLE
Add trusty-backports source + shellcheck

### DIFF
--- a/cookbooks/travis_build_environment/recipes/apt.rb
+++ b/cookbooks/travis_build_environment/recipes/apt.rb
@@ -73,6 +73,8 @@ end
   execute "apt-add-repository -y #{source_alias}"
 end
 
+execute 'apt-add-repository -y "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse"'
+
 execute 'gencaches for travis_build_environment::apt' do
   command 'apt-cache gencaches'
 end

--- a/cookbooks/travis_build_environment/recipes/basic.rb
+++ b/cookbooks/travis_build_environment/recipes/basic.rb
@@ -40,7 +40,6 @@ package %w(
   openssl
   ragel
   rsync
-  shellcheck
   sqlite3
   sqlite3-doc
   subversion
@@ -71,3 +70,9 @@ include_recipe 'travis_build_environment::heroku_toolbelt'
 include_recipe 'travis_build_environment::locale'
 include_recipe 'travis_build_environment::hostname'
 include_recipe 'travis_build_environment::sysctl'
+
+package %w(
+  shellcheck
+) do
+  action [:install, :upgrade]
+end

--- a/cookbooks/travis_build_environment/recipes/basic.rb
+++ b/cookbooks/travis_build_environment/recipes/basic.rb
@@ -40,6 +40,7 @@ package %w(
   openssl
   ragel
   rsync
+  shellcheck
   sqlite3
   sqlite3-doc
   subversion


### PR DESCRIPTION
to `travis_build_environment` cookbooks.