### PR TITLE
Ensure no ~travis/.pearrc file is left over

### DIFF
--- a/cookbooks/travis_build_environment/recipes/ci_user.rb
+++ b/cookbooks/travis_build_environment/recipes/ci_user.rb
@@ -307,3 +307,12 @@ bash 'set global default php' do
   environment('HOME' => node['travis_build_environment']['home'])
   not_if { Array(node['travis_build_environment']['php_versions']).empty? }
 end
+
+bash 'remove ~travis/.pearrc' do
+  code "rm -f #{node['travis_build_environment']['home']}/.pearrc"
+  action :nothing
+end
+
+log 'trigger ~travis/.pearrc removal' do
+  notifies :run, 'bash[remove ~travis/.pearrc]'
+end


### PR DESCRIPTION
after preinstallation of php versions