### PR TITLE
Explicitly create user's home dir

### DIFF
--- a/cookbooks/travis_users/recipes/default.rb
+++ b/cookbooks/travis_users/recipes/default.rb
@@ -36,6 +36,12 @@ Array(node['travis_users']).each do |user|
     shell user['shell']
   end
 
+  directory "/home/#{user['id']}" do
+    mode 0o750
+    owner user['id']
+    group user['id']
+  end
+
   file "/home/#{user['id']}/.zshrc" do
     content "# this space intentionally left blank\n"
     mode 0o640


### PR DESCRIPTION
since it appears that newer versions of Chef may not block on creating this
before moving along