### PR TITLE
Ensure travis-worker temporary env file exists

### DIFF
--- a/cookbooks/travis_worker/templates/default/etc-init-travis-worker.conf.erb
+++ b/cookbooks/travis_worker/templates/default/etc-init-travis-worker.conf.erb
@@ -19,6 +19,7 @@ post-stop exec sleep 5
 script
   mkdir -p /var/tmp/travis-run.d
   _TMP_ENV="/var/tmp/travis-run.d/env.`date -u +%s`"
+  touch "${_TMP_ENV}"
 
   for config_file in travis-enterprise \
                      "${UPSTART_JOB}-chef" \


### PR DESCRIPTION
even if none of the defaults files do