### PR TITLE
Update pypy to version 5.4.1

### DIFF
--- a/cookbooks/pypy/README.md
+++ b/cookbooks/pypy/README.md
@@ -1,1 +1,3 @@
 # pypy cookbook
+
+Updated to 5.4.1

--- a/cookbooks/pypy/attributes/default.rb
+++ b/cookbooks/pypy/attributes/default.rb
@@ -1,4 +1,4 @@
-version = '2.3'
+version = '5.4.1'
 arch    = kernel['machine'] =~ /x86_64/ ? 'amd64' : 'i386'
 linux_arch = arch == 'amd64' ? 'linux64' : 'linux'
 
@@ -6,9 +6,9 @@ default[:pypy] = {
   tarball: {
     version: version,
     arch: arch,
-    url: "https://bitbucket.org/pypy/pypy/downloads/pypy-#{version}-#{linux_arch}.tar.bz2",
-    filename: "pypy-#{version}-#{linux_arch}.tar.bz2",
-    dirname: "pypy-#{version}-#{linux_arch}",
+    url: "https://bitbucket.org/pypy/pypy/downloads/pypy2-v#{version}-#{linux_arch}.tar.bz2",
+    filename: "pypy2-v#{version}-#{linux_arch}.tar.bz2",
+    dirname: "pypy2-v#{version}-#{linux_arch}",
     installation_dir: '/usr/local/pypy'
   }
 }

--- a/cookbooks/travis_python/attributes/default.rb
+++ b/cookbooks/travis_python/attributes/default.rb
@@ -9,13 +9,13 @@ default['travis_python']['pyenv']['revision'] = 'v1.0.0'
 default['travis_python']['pyenv']['pythons'] = %w(
   2.7.12
   3.5.2
-  pypy-5.3.1
+  pypy2-5.4.1
 )
 
 default['travis_python']['pyenv']['aliases'] = {
   '2.7.12' => %w(2.7),
   '3.5.2' => %w(3.5),
-  'pypy-2.6.1' => %w(pypy)
+  'pypy2-5.4.1' => %w(pypy)
 }
 
 default['travis_python']['pip']['packages'] = {


### PR DESCRIPTION
Trying to fix these:
https://github.com/travis-ci/travis-ci/issues/4756
https://github.com/travis-ci/travis-ci/issues/5027

Actually I'm not sure if these need to be added at all or if it's a documentation issue, since I see from the comments on https://github.com/travis-ci/travis-ci/issues/6553 that 5.4 is available?
