### PR TITLE
Comment out codehaus-snapshots

### DIFF
--- a/ci_environment/travis_build_environment/files/default/ci_user/maven_user_settings.xml
+++ b/ci_environment/travis_build_environment/files/default/ci_user/maven_user_settings.xml
@@ -83,6 +83,9 @@
           <url>https://repository.apache.org/snapshots/</url>
         </repository>
 
+        <!-- codehaus.org is no longer available, see https://github.com/travis-ci/travis-ci/issues/4629 -->
+        <!-- commenting out instead of removing to avoid breaking `before_install` workarounds -->
+        <!--
         <repository>
           <id>codehaus-snapshots</id>
           <name>Codehaus (snapshots)</name>
@@ -98,6 +101,7 @@
           </snapshots>
           <url>https://nexus.codehaus.org/snapshots/</url>
         </repository>
+        -->
       </repositories>
     </profile>
   </profiles>


### PR DESCRIPTION
This Maven repository is no longer online. It is commented out rather than removed entirely, as some people have implemented workarounds running `sed` in a `before_install` script. Removing the lines from the file entirely would cause those builds to fail.

Fixes travis-ci/travis-ci#4629.