### PR TITLE
Lock down iptables (more) in build environments

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -146,6 +146,7 @@ default['travis_build_environment']['gimme']['debug'] = false
 
 default['travis_build_environment']['sysctl_kernel_shmmax'] = 45_794_432
 default['travis_build_environment']['sysctl_disable_ipv6'] = true
+default['travis_build_environment']['ssh_host_key_regen'] = false
 default['travis_build_environment']['wget']['version'] = '1.18'
 
 default['tz'] = 'UTC'

--- a/cookbooks/travis_build_environment/files/default/cloud-init-per-boot-iptables-lockdown.bash
+++ b/cookbooks/travis_build_environment/files/default/cloud-init-per-boot-iptables-lockdown.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -o errexit
+
+main() {
+  echo 'applying iptables rules for CI test VM isolation'
+  # TODO: do the stuff with the iptables
+}
+
+main "$@"

--- a/cookbooks/travis_build_environment/files/default/cloud-init-per-boot-iptables-lockdown.bash
+++ b/cookbooks/travis_build_environment/files/default/cloud-init-per-boot-iptables-lockdown.bash
@@ -2,8 +2,13 @@
 set -o errexit
 
 main() {
-  echo 'applying iptables rules for CI test VM isolation'
-  # TODO: do the stuff with the iptables
+  set -o xtrace
+  iptables -I INPUT 1 -p icmp -j ACCEPT
+  iptables -I INPUT 2 -p udp --dport 33434:33523 -j REJECT
+  iptables -I INPUT 3 -i lo -j ACCEPT
+  iptables -I INPUT 4 -m state --state ESTABLISHED,RELATED -j ACCEPT
+  iptables -I INPUT 5 -p tcp --dport ssh -j ACCEPT
+  iptables -A INPUT -j DROP
 }
 
 main "$@"

--- a/cookbooks/travis_build_environment/files/default/cloud-init-per-boot-iptables-lockdown.bash
+++ b/cookbooks/travis_build_environment/files/default/cloud-init-per-boot-iptables-lockdown.bash
@@ -3,12 +3,12 @@ set -o errexit
 
 main() {
   set -o xtrace
-  iptables -I INPUT 1 -p icmp -j ACCEPT
-  iptables -I INPUT 2 -p udp --dport 33434:33523 -j REJECT
-  iptables -I INPUT 3 -i lo -j ACCEPT
-  iptables -I INPUT 4 -m state --state ESTABLISHED,RELATED -j ACCEPT
-  iptables -I INPUT 5 -p tcp --dport ssh -j ACCEPT
-  iptables -A INPUT -j DROP
+  sudo iptables -I INPUT 1 -p icmp -j ACCEPT
+  sudo iptables -I INPUT 2 -p udp --dport 33434:33523 -j REJECT
+  sudo iptables -I INPUT 3 -i lo -j ACCEPT
+  sudo iptables -I INPUT 4 -m state --state ESTABLISHED,RELATED -j ACCEPT
+  sudo iptables -I INPUT 5 -p tcp --dport ssh -j ACCEPT
+  sudo iptables -A INPUT -j DROP
 }
 
 main "$@"

--- a/cookbooks/travis_build_environment/recipes/security.rb
+++ b/cookbooks/travis_build_environment/recipes/security.rb
@@ -61,7 +61,7 @@ end
 
 execute '/usr/sbin/update-ca-certificates -f'
 
-cookbook_file '/var/lib/cloud/scripts/per-boot/iptables-lockdown' do
+cookbook_file '/var/lib/cloud/scripts/per-boot/99-travis-iptables-lockdown' do
   source 'cloud-init-per-boot-iptables-lockdown.bash'
   owner 'root'
   group 'root'

--- a/cookbooks/travis_build_environment/recipes/security.rb
+++ b/cookbooks/travis_build_environment/recipes/security.rb
@@ -60,3 +60,11 @@ template '/etc/init.d/disable-apparmor' do
 end
 
 execute '/usr/sbin/update-ca-certificates -f'
+
+cookbook_file '/var/lib/cloud/scripts/per-boot/iptables-lockdown' do
+  source 'cloud-init-per-boot-iptables-lockdown.bash'
+  owner 'root'
+  group 'root'
+  mode 0755
+  only_if { File.directory?('/var/lib/cloud/scripts/per-boot') }
+end

--- a/cookbooks/travis_build_environment/templates/default/etc/cloud/cloud.cfg.erb
+++ b/cookbooks/travis_build_environment/templates/default/etc/cloud/cloud.cfg.erb
@@ -30,25 +30,15 @@ cloud_config_modules:
 - emit_upstart
 - disk_setup
 - mounts
-- ssh-import-id
 - locale
-- set-passwords
 - grub-dpkg
 - apt-pipelining
 - apt-configure
-- package-update-upgrade-install
-- landscape
 - timezone
-- puppet
-- chef
-- salt-minion
-- mcollective
 - disable-ec2-metadata
 - runcmd
-- byobu
 
 cloud_final_modules:
-- rightscale_userdata
 - scripts-vendor
 - scripts-per-once
 - scripts-per-boot
@@ -56,14 +46,13 @@ cloud_final_modules:
 - scripts-user
 - ssh-authkey-fingerprints
 - keys-to-console
-- phone-home
 - final-message
 - power-state-change
 
 system_info:
   distro: ubuntu
   default_user:
-    name: ubuntu
+    name: travis
     lock_passwd: True
     gecos: Ubuntu
     groups: [adm, audio, cdrom, dialout, dip, floppy, netdev, plugdev, sudo, video]
@@ -73,19 +62,4 @@ system_info:
     cloud_dir: /var/lib/cloud/
     templates_dir: /etc/cloud/templates/
     upstart_dir: /etc/init/
-  package_mirrors:
-  - arches: [i386, amd64]
-    failsafe:
-      primary: 'http://archive.ubuntu.com/ubuntu'
-      security: 'http://security.ubuntu.com/ubuntu'
-    search:
-      primary:
-      - 'http://%(ec2_region)s.ec2.archive.ubuntu.com/ubuntu/'
-      - 'http://%(availability_zone)s.clouds.archive.ubuntu.com/ubuntu/'
-      - 'http://%(region)s.clouds.archive.ubuntu.com/ubuntu/'
-      security: []
-  - arches: [armhf, armel, default]
-    failsafe:
-      primary: 'http://ports.ubuntu.com/ubuntu-ports'
-      security: 'http://ports.ubuntu.com/ubuntu-ports'
   ssh_svcname: ssh

--- a/cookbooks/travis_build_environment/templates/default/etc/cloud/cloud.cfg.erb
+++ b/cookbooks/travis_build_environment/templates/default/etc/cloud/cloud.cfg.erb
@@ -2,17 +2,10 @@
 ## cookbook:: travis_build_environment
 ##     file:: templates/default/etc/cloud/cloud.cfg.erb
 
-users:
-- travis
-
 disable_root: true
-
 preserve_hostname: false
-
 manage_etc_hosts: template
-
 cloud_init_modules:
-- migrator
 - seed_random
 - bootcmd
 - write-files
@@ -21,45 +14,17 @@ cloud_init_modules:
 - set_hostname
 - update_hostname
 - update_etc_hosts
-- ca-certs
-- rsyslog
-- users-groups
+<% if node['travis_build_environment']['ssh_host_key_regen'] %>
 - ssh
-
+<% end %>
 cloud_config_modules:
 - emit_upstart
-- disk_setup
-- mounts
-- locale
-- grub-dpkg
 - apt-pipelining
 - apt-configure
-- timezone
-- disable-ec2-metadata
 - runcmd
-
 cloud_final_modules:
 - scripts-vendor
 - scripts-per-once
 - scripts-per-boot
 - scripts-per-instance
 - scripts-user
-- ssh-authkey-fingerprints
-- keys-to-console
-- final-message
-- power-state-change
-
-system_info:
-  distro: ubuntu
-  default_user:
-    name: travis
-    lock_passwd: True
-    gecos: Ubuntu
-    groups: [adm, audio, cdrom, dialout, dip, floppy, netdev, plugdev, sudo, video]
-    sudo: ['ALL=(ALL) NOPASSWD:ALL']
-    shell: /bin/bash
-  paths:
-    cloud_dir: /var/lib/cloud/
-    templates_dir: /etc/cloud/templates/
-    upstart_dir: /etc/init/
-  ssh_svcname: ssh


### PR DESCRIPTION
including ripping out a bunch of cargo-culted-cloud-config that we neither need nor want.
- [x] fill in the `iptables` stuff
- [ ] works as intended?
