### PR TITLE
Bump some worker and docker bits up a bit

### DIFF
--- a/cookbooks/travis_docker/recipes/package.rb
+++ b/cookbooks/travis_docker/recipes/package.rb
@@ -30,7 +30,9 @@ apt_repository 'docker' do
   action :add
 end
 
-package 'linux-generic-lts-xenial'
+package %w(linux-generic-lts-xenial linux-image-generic-lts-xenial) do
+  action %i(install upgrade)
+end
 
 package 'docker-engine' do
   version node['travis_docker']['version']

--- a/cookbooks/travis_worker/attributes/default.rb
+++ b/cookbooks/travis_worker/attributes/default.rb
@@ -5,7 +5,7 @@ default['travis_worker']['branch'] = ''
 default['travis_worker']['disable_reconfiguration'] = false
 
 # The members under `environment` should be the exact env vars
-default['travis_worker']['environment']['TRAVIS_WORKER_SELF_IMAGE'] = 'quay.io/travisci/worker:v2.4.0'
+default['travis_worker']['environment']['TRAVIS_WORKER_SELF_IMAGE'] = 'quay.io/travisci/worker:v2.5.0'
 
 # The members under `environment` should be the exact env vars
 default['travis_worker']['docker']['environment']['TRAVIS_WORKER_DISABLE_DIRECT_LVM'] = ''


### PR DESCRIPTION
- bumping the worker docker image for general tidyness, as this value is
  overridden in the wrapper cookbook
- explicitly installing and upgrading the backported xenial kernel in order to
  (hopefully) get the latest patches related to `unregister_netdevice`