### PR TITLE
Conditionally write a redis-server sysvinit shim

### DIFF
--- a/cookbooks/redis/attributes/default.rb
+++ b/cookbooks/redis/attributes/default.rb
@@ -1,1 +1,2 @@
 default['redis']['service']['enabled'] = false
+default['redis']['write_sysvinit_shim'] = false

--- a/cookbooks/redis/files/default/etc-init-d-redis-server.sh
+++ b/cookbooks/redis/files/default/etc-init-d-redis-server.sh
@@ -1,0 +1,89 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:             redis-server
+# Required-Start:       $syslog $remote_fs
+# Required-Stop:        $syslog $remote_fs
+# Should-Start:         $local_fs
+# Should-Stop:          $local_fs
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    redis-server - Persistent key-value db
+# Description:          redis-server - Persistent key-value db
+### END INIT INFO
+
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/bin/redis-server
+DAEMON_ARGS=/etc/redis/redis.conf
+NAME=redis-server
+DESC=redis-server
+
+RUNDIR=/var/run/redis
+PIDFILE=$RUNDIR/redis-server.pid
+
+test -x $DAEMON || exit 0
+
+if [ -r /etc/default/$NAME ]
+then
+        . /etc/default/$NAME
+fi
+
+. /lib/lsb/init-functions
+
+set -e
+
+case "$1" in
+  start)
+        echo -n "Starting $DESC: "
+        mkdir -p $RUNDIR
+        touch $PIDFILE
+        chown redis:redis $RUNDIR $PIDFILE
+        chmod 755 $RUNDIR
+
+        if [ -n "$ULIMIT" ]
+        then
+                ulimit -n $ULIMIT
+        fi
+
+        if start-stop-daemon --start --quiet --umask 007 --pidfile $PIDFILE --chuid redis:redis --exec $DAEMON -- $DAEMON_ARGS
+        then
+                echo "$NAME."
+        else
+                echo "failed"
+        fi
+        ;;
+  stop)
+        echo -n "Stopping $DESC: "
+        if start-stop-daemon --stop --retry forever/TERM/1 --quiet --oknodo --pidfile $PIDFILE --exec $DAEMON
+        then
+                echo "$NAME."
+        else
+                echo "failed"
+        fi
+        rm -f $PIDFILE
+        sleep 1
+        ;;
+
+  restart|force-reload)
+        ${0} stop
+        ${0} start
+        ;;
+
+  status)
+        echo -n "$DESC is "
+        if start-stop-daemon --stop --quiet --signal 0 --name ${NAME} --pidfile ${PIDFILE}
+        then
+                echo "running"
+        else
+                echo "not running"
+                exit 1
+        fi
+        ;;
+
+  *)
+        echo "Usage: /etc/init.d/$NAME {start|stop|restart|force-reload|status}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/cookbooks/redis/recipes/default.rb
+++ b/cookbooks/redis/recipes/default.rb
@@ -24,7 +24,7 @@
 apt_repository 'rwky-redis' do
   uri 'http://ppa.launchpad.net/rwky/redis/ubuntu'
   distribution node['lsb']['codename']
-  components ['main']
+  components %w(main)
   key '5862E31D'
   keyserver 'hkp://ha.pool.sks-keyservers.net'
   retries 2
@@ -36,12 +36,20 @@ package 'redis-server' do
   action :install
 end
 
+cookbook_file '/etc/init.d/redis-server' do
+  source 'etc-init-d-redis-server.sh'
+  owner 'root'
+  group 'root'
+  mode 0o755
+  only_if { node['redis']['write_sysvinit_shim'] }
+end
+
 service 'redis-server' do
   provider Chef::Provider::Service::Upstart
   supports restart: true, status: true, reload: true
   if node.redis.service.enabled
-    action [:enable, :start]
+    action %i(enable start)
   else
-    action [:disable, :start]
+    action %i(disable start)
   end
 end


### PR DESCRIPTION
mostly in case the switch to a docker image with fully-functioning upstart doesn't work out