### PR TITLE
Remove `./node_modules/bin` from `$PATH`

### DIFF
--- a/cookbooks/nodejs/templates/default/nvm.sh.erb
+++ b/cookbooks/nodejs/templates/default/nvm.sh.erb
@@ -1,3 +1,2 @@
 export NVM_DIR=<%= node.travis_build_environment.home %>/.nvm
-export PATH="./node_modules/.bin":$PATH
 . $NVM_DIR/nvm.sh


### PR DESCRIPTION
Some Node.js modules provide commands with names identical to well-known commands (including `bash` builtin functions such as `which`). This causes confusing issues when other software assumes that `which` behaves a certain way (see https://github.com/travis-ci/travis-ci/issues/5092).

While we have a good reason to add `./node_modules/bin` to `$PATH`, a consensus among Node.js users is that it shouldn't be.

Removing this from `$PATH` may very well break some builds, but we will address that by writing a message to the logs with `travis-build`. (This will be done separately.)