### PR TITLE
Set travis-rubies vars in ~/.rvmrc

### DIFF
--- a/ci_environment/rvm/templates/default/dot_rvmrc.sh.erb
+++ b/ci_environment/rvm/templates/default/dot_rvmrc.sh.erb
@@ -6,3 +6,6 @@ export rvm_max_time_flag=5
 export rvm_autoupdate_flag=0
 export rvm_without_gems="rubygems-bundler"
 export rvm_with_default_gems="rake=~>10.2.2 bundler=~>1.6.0"
+export rvm_remote_server_type4=rubies
+export rvm_remote_server_url4='https://s3.amazonaws.com/travis-rubies/binaries'
+export rvm_remote_server_verify_downloads4=1


### PR DESCRIPTION
which are also set at travis-build time, but we could also use them during chef
time.