### PR TITLE
Remove dead Codehaus snapshots Maven repository

### DIFF
--- a/cookbooks/travis_build_environment/files/default/ci_user/maven_user_settings.xml
+++ b/cookbooks/travis_build_environment/files/default/ci_user/maven_user_settings.xml
@@ -82,22 +82,6 @@
           </snapshots>
           <url>https://repository.apache.org/snapshots/</url>
         </repository>
-
-        <repository>
-          <id>codehaus-snapshots</id>
-          <name>Codehaus (snapshots)</name>
-          <releases>
-            <enabled>false</enabled>
-            <updatePolicy>always</updatePolicy>
-            <checksumPolicy>warn</checksumPolicy>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-            <checksumPolicy>fail</checksumPolicy>
-          </snapshots>
-          <url>https://nexus.codehaus.org/snapshots/</url>
-        </repository>
       </repositories>
     </profile>
   </profiles>


### PR DESCRIPTION
Codehaus has been permanently offline since April 2015.