### PR TITLE
Use sdkmanager for Android builds

### DIFF
--- a/community-cookbooks/android-sdk/attributes/default.rb
+++ b/community-cookbooks/android-sdk/attributes/default.rb
@@ -5,9 +5,10 @@ default['android-sdk']['setup_root']                = nil  # ark defaults (/usr/
 default['android-sdk']['with_symlink']              = true # use ark's :install action when true; use ark's :put action when false
 default['android-sdk']['set_environment_variables'] = true
 
-default['android-sdk']['version']                   = '24.4'
-default['android-sdk']['checksum']                  = 'f2bb546534d16e2004665257ee530060338c684adad14a49cd4bbde08098d8a4'
-default['android-sdk']['download_url']              = "http://dl.google.com/android/android-sdk_r#{node['android-sdk']['version']}-linux.tgz"
+default['android-sdk']['version']                   = '25.2.3'
+default['android-sdk']['checksum']                  = 'aafe7f28ac51549784efc2f3bdfc620be8a08213'
+default['android-sdk']['download_url']              = "https://dl.google.com/android/repository/tools_r#{node['android-sdk']['version']}-linux.zip"
+
 
 #
 # List of Android SDK components to preinstall:

--- a/community-cookbooks/android-sdk/recipes/default.rb
+++ b/community-cookbooks/android-sdk/recipes/default.rb
@@ -27,7 +27,7 @@ include_recipe 'java' unless node['android-sdk']['java_from_system']
 
 setup_root       = node['android-sdk']['setup_root'].to_s.empty? ? node['ark']['prefix_home'] : node['android-sdk']['setup_root']
 android_home     = File.join(setup_root, node['android-sdk']['name'])
-android_bin      = File.join(android_home, 'tools', 'android')
+android_bin      = File.join(android_home, 'tools', 'bin')
 
 #
 # Install required libraries
@@ -121,7 +121,7 @@ unless File.exist?("#{setup_root}/#{node['android-sdk']['name']}/temp")
       group node['android-sdk']['group']
       # TODO: use --force or not?
       code <<-EOF
-        spawn #{android_bin} update sdk --no-ui --all --filter #{sdk_component}
+        spawn #{android_bin}sdkmanager sdk #{sdk_component}
         set timeout 1800
         expect {
           -regexp "Do you accept the license '(#{node['android-sdk']['license']['white_list'].join('|')})'.*" {


### PR DESCRIPTION
First of all, let me say I have no experience setting up a cookbook. 

I am trying to get the ball rolling on updating Android builds to use sdkmanager instead of the now somewhat obsolete `update` command.

Main reasoning for this is that certain newer features in the SDK are only available to download via the `sdkmanager` command line tool, such as CMake for Android builds (see [this issue](https://code.google.com/p/android/issues/detail?id=221907))

The tests are passing on my repo, but I have doubts that I have set this up correctly. For reference, here is how I use `sdkmanager` on builds done on GitLab CI

https://gitlab.com/Commit451/LabCoat/blob/master/.gitlab-ci.yml

Is there someone who can help me out on this? Possibly @gildegoma ?