### PR TITLE
Trusty Cookbook Updates for Build Environment 

### DIFF
--- a/cookbooks/travis_build_environment/recipes/redis.rb
+++ b/cookbooks/travis_build_environment/recipes/redis.rb
@@ -1,9 +1,9 @@
-apt_repository 'rwky-redis' do
-  uri 'http://ppa.launchpad.net/rwky/redis/ubuntu'
+apt_repository 'chris-lea-redis-server' do
+  uri 'http://ppa.launchpad.net/chris-lea/redis-server/ubuntu'
   distribution node['lsb']['codename']
   components ['main']
-  key '5862E31D'
-  keyserver 'hkp://ha.pool.sks-keyservers.net'
+  key 'C7917B12'
+  keyserver 'hkp://keyserver.ubuntu.com'
   retries 2
   retry_delay 30
   action :add

--- a/cookbooks/travis_build_environment/recipes/redis.rb
+++ b/cookbooks/travis_build_environment/recipes/redis.rb
@@ -14,7 +14,7 @@ package 'redis-server' do
 end
 
 service 'redis-server' do
-  provider Chef::Provider::Service::Init::Debian, service
+  provider Chef::Provider::Service::Init::Debian
   supports restart: true, status: true, reload: true
   if node['travis_build_environment']['redis']['service_enabled']
     action %i(enable start)

--- a/cookbooks/travis_build_environment/recipes/redis.rb
+++ b/cookbooks/travis_build_environment/recipes/redis.rb
@@ -14,7 +14,7 @@ package 'redis-server' do
 end
 
 service 'redis-server' do
-  provider Chef::Provider::Service::Upstart
+  provider Chef::Provider::Service::Init::Debian, service
   supports restart: true, status: true, reload: true
   if node['travis_build_environment']['redis']['service_enabled']
     action %i(enable start)

--- a/cookbooks/travis_build_environment/recipes/rvm.rb
+++ b/cookbooks/travis_build_environment/recipes/rvm.rb
@@ -49,7 +49,7 @@ end
 
 remote_file gpg_key_path do
   source 'https://rvm.io/mpapis.asc'
-  checksum '6ba1ebe6b02841db9ea3b73b85d4ede87192584efc7dfe13fe42a29416767ffa'
+  checksum '08f64631c598cbe4398c5850725c8e6ab60dc5d86b6214e069d7ced1d546043b'
   owner node['travis_build_environment']['user']
   group node['travis_build_environment']['group']
   mode 0o644


### PR DESCRIPTION
I renamed the cha-md5sum-fix branch to this currenet `cha-trusty-update`, since the branch is broader in scope.  Renaming and pushing new branch name closed old PR, this is its replacement.