### PR TITLE
Limit docker repo to amd64 as it does in its own install script

### DIFF
--- a/cookbooks/travis_docker/recipes/package.rb
+++ b/cookbooks/travis_docker/recipes/package.rb
@@ -22,6 +22,7 @@
 
 apt_repository 'docker' do
   uri 'https://download.docker.com/linux/ubuntu'
+  arch 'amd64'
   distribution 'trusty'
   components %w(stable edge)
   key 'https://download.docker.com/linux/ubuntu/gpg'


### PR DESCRIPTION
To address https://github.com/travis-pro/team-blue/issues/715