### PR TITLE
Add changes to support xenial distribution on ppc64le for Sugilite run_list

### DIFF
--- a/cookbooks/travis_build_environment/files/default/cassandra.jvm.options
+++ b/cookbooks/travis_build_environment/files/default/cassandra.jvm.options
@@ -1,0 +1,245 @@
+###########################################################################
+#                             jvm.options                                 #
+#                                                                         #
+# - all flags defined here will be used by cassandra to startup the JVM   #
+# - one flag should be specified per line                                 #
+# - lines that do not start with '-' will be ignored                      #
+# - only static flags are accepted (no variables or parameters)           #
+# - dynamic flags will be appended to these on cassandra-env              #
+###########################################################################
+
+######################
+# STARTUP PARAMETERS #
+######################
+
+# Uncomment any of the following properties to enable specific startup parameters
+
+# In a multi-instance deployment, multiple Cassandra instances will independently assume that all
+# CPU processors are available to it. This setting allows you to specify a smaller set of processors
+# and perhaps have affinity.
+#-Dcassandra.available_processors=number_of_processors
+
+# The directory location of the cassandra.yaml file.
+#-Dcassandra.config=directory
+
+# Sets the initial partitioner token for a node the first time the node is started.
+#-Dcassandra.initial_token=token
+
+# Set to false to start Cassandra on a node but not have the node join the cluster.
+#-Dcassandra.join_ring=true|false
+
+# Set to false to clear all gossip state for the node on restart. Use when you have changed node
+# information in cassandra.yaml (such as listen_address).
+#-Dcassandra.load_ring_state=true|false
+
+# Enable pluggable metrics reporter. See Pluggable metrics reporting in Cassandra 2.0.2.
+#-Dcassandra.metricsReporterConfigFile=file
+
+# Set the port on which the CQL native transport listens for clients. (Default: 9042)
+#-Dcassandra.native_transport_port=port
+
+# Overrides the partitioner. (Default: org.apache.cassandra.dht.Murmur3Partitioner)
+#-Dcassandra.partitioner=partitioner
+
+# To replace a node that has died, restart a new node in its place specifying the address of the
+# dead node. The new node must not have any data in its data directory, that is, it must be in the
+# same state as before bootstrapping.
+#-Dcassandra.replace_address=listen_address or broadcast_address of dead node
+
+# Allow restoring specific tables from an archived commit log.
+#-Dcassandra.replayList=table
+
+# Allows overriding of the default RING_DELAY (1000ms), which is the amount of time a node waits
+# before joining the ring.
+#-Dcassandra.ring_delay_ms=ms
+
+# Set the port for the Thrift RPC service, which is used for client connections. (Default: 9160)
+#-Dcassandra.rpc_port=port
+
+# Set the SSL port for encrypted communication. (Default: 7001)
+#-Dcassandra.ssl_storage_port=port
+
+# Enable or disable the native transport server. See start_native_transport in cassandra.yaml.
+# cassandra.start_native_transport=true|false
+
+# Enable or disable the Thrift RPC server. (Default: true)
+#-Dcassandra.start_rpc=true/false
+
+# Set the port for inter-node communication. (Default: 7000)
+#-Dcassandra.storage_port=port
+
+# Set the default location for the trigger JARs. (Default: conf/triggers)
+#-Dcassandra.triggers_dir=directory
+
+# For testing new compaction and compression strategies. It allows you to experiment with different
+# strategies and benchmark write performance differences without affecting the production workload. 
+#-Dcassandra.write_survey=true
+
+# To disable configuration via JMX of auth caches (such as those for credentials, permissions and
+# roles). This will mean those config options can only be set (persistently) in cassandra.yaml
+# and will require a restart for new values to take effect.
+#-Dcassandra.disable_auth_caches_remote_configuration=true
+
+# To disable dynamic calculation of the page size used when indexing an entire partition (during
+# initial index build/rebuild). If set to true, the page size will be fixed to the default of
+# 10000 rows per page.
+#-Dcassandra.force_default_indexing_page_size=true
+
+########################
+# GENERAL JVM SETTINGS #
+########################
+
+# enable assertions. highly suggested for correct application functionality.
+-ea
+
+# enable thread priorities, primarily so we can give periodic tasks
+# a lower priority to avoid interfering with client workload
+-XX:+UseThreadPriorities
+
+# allows lowering thread priority without being root on linux - probably
+# not necessary on Windows but doesn't harm anything.
+# see http://tech.stolsvik.com/2010/01/linux-java-thread-priorities-workar
+-XX:ThreadPriorityPolicy=42
+
+# Enable heap-dump if there's an OOM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# Per-thread stack size.
+-Xss512k
+
+# Larger interned string table, for gossip's benefit (CASSANDRA-6410)
+-XX:StringTableSize=1000003
+
+# Make sure all memory is faulted and zeroed on startup.
+# This helps prevent soft faults in containers and makes
+# transparent hugepage allocation more effective.
+-XX:+AlwaysPreTouch
+
+# Disable biased locking as it does not benefit Cassandra.
+-XX:-UseBiasedLocking
+
+# Enable thread-local allocation blocks and allow the JVM to automatically
+# resize them at runtime.
+-XX:+UseTLAB
+-XX:+ResizeTLAB
+-XX:+UseNUMA
+
+# http://www.evanjones.ca/jvm-mmap-pause.html
+-XX:+PerfDisableSharedMem
+
+# Prefer binding to IPv4 network intefaces (when net.ipv6.bindv6only=1). See
+# http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6342561 (short version:
+# comment out this entry to enable IPv6 support).
+-Djava.net.preferIPv4Stack=true
+
+### Debug options
+
+# uncomment to enable flight recorder
+#-XX:+UnlockCommercialFeatures
+#-XX:+FlightRecorder
+
+# uncomment to have Cassandra JVM listen for remote debuggers/profilers on port 1414
+#-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1414
+
+# uncomment to have Cassandra JVM log internal method compilation (developers only)
+#-XX:+UnlockDiagnosticVMOptions
+#-XX:+LogCompilation
+
+#################
+# HEAP SETTINGS #
+#################
+
+# Heap size is automatically calculated by cassandra-env based on this
+# formula: max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
+# That is:
+# - calculate 1/2 ram and cap to 1024MB
+# - calculate 1/4 ram and cap to 8192MB
+# - pick the max
+#
+# For production use you may wish to adjust this for your environment.
+# If that's the case, uncomment the -Xmx and Xms options below to override the
+# automatic calculation of JVM heap memory.
+#
+# It is recommended to set min (-Xms) and max (-Xmx) heap sizes to
+# the same value to avoid stop-the-world GC pauses during resize, and
+# so that we can lock the heap in memory on startup to prevent any
+# of it from being swapped out.
+#-Xms4G
+#-Xmx4G
+
+# Young generation size is automatically calculated by cassandra-env
+# based on this formula: min(100 * num_cores, 1/4 * heap size)
+#
+# The main trade-off for the young generation is that the larger it
+# is, the longer GC pause times will be. The shorter it is, the more
+# expensive GC will be (usually).
+#
+# It is not recommended to set the young generation size if using the
+# G1 GC, since that will override the target pause-time goal.
+# More info: http://www.oracle.com/technetwork/articles/java/g1gc-1984535.html
+#
+# The example below assumes a modern 8-core+ machine for decent
+# times. If in doubt, and if you do not particularly want to tweak, go
+# 100 MB per physical CPU core.
+#-Xmn800M
+
+#################
+#  GC SETTINGS  #
+#################
+
+### CMS Settings
+
+-XX:+UseParNewGC
+-XX:+UseConcMarkSweepGC
+-XX:+CMSParallelRemarkEnabled
+-XX:SurvivorRatio=8
+-XX:MaxTenuringThreshold=1
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+-XX:CMSWaitDuration=10000
+-XX:+CMSParallelInitialMarkEnabled
+-XX:+CMSEdenChunksRecordAlways
+# some JVMs will fill up their heap when accessed via JMX, see CASSANDRA-6541
+-XX:+CMSClassUnloadingEnabled
+
+### G1 Settings (experimental, comment previous section and uncomment section below to enable)
+
+## Use the Hotspot garbage-first collector.
+#-XX:+UseG1GC
+#
+## Have the JVM do less remembered set work during STW, instead
+## preferring concurrent GC. Reduces p99.9 latency.
+#-XX:G1RSetUpdatingPauseTimePercent=5
+#
+## Main G1GC tunable: lowering the pause target will lower throughput and vise versa.
+## 200ms is the JVM default and lowest viable setting
+## 1000ms increases throughput. Keep it smaller than the timeouts in cassandra.yaml.
+#-XX:MaxGCPauseMillis=500
+
+## Optional G1 Settings
+
+# Save CPU time on large (>= 16GB) heaps by delaying region scanning
+# until the heap is 70% full. The default in Hotspot 8u40 is 40%.
+#-XX:InitiatingHeapOccupancyPercent=70
+
+# For systems with > 8 cores, the default ParallelGCThreads is 5/8 the number of logical cores.
+# Otherwise equal to the number of cores when 8 or less.
+# Machines with > 10 cores should try setting these to <= full cores.
+#-XX:ParallelGCThreads=16
+# By default, ConcGCThreads is 1/4 of ParallelGCThreads.
+# Setting both to the same value can reduce STW durations.
+#-XX:ConcGCThreads=16
+
+### GC logging options -- uncomment to enable
+
+-XX:+PrintGCDetails
+-XX:+PrintGCDateStamps
+-XX:+PrintHeapAtGC
+-XX:+PrintTenuringDistribution
+-XX:+PrintGCApplicationStoppedTime
+-XX:+PrintPromotionFailure
+#-XX:PrintFLSStatistics=1
+#-Xloggc:/var/log/cassandra/gc.log
+-XX:+UseGCLogFileRotation
+-XX:NumberOfGCLogFiles=10
+-XX:GCLogFileSize=10M

--- a/cookbooks/travis_build_environment/recipes/cassandra.rb
+++ b/cookbooks/travis_build_environment/recipes/cassandra.rb
@@ -4,10 +4,30 @@ apt_repository 'cassandra' do
   distribution ''
   key 'A278B781FE4B2BDA'
   keyserver 'hkp://ha.pool.sks-keyservers.net'
+  not_if { node['kernel']['machine'] == 'ppc64le' }
+end
+
+apt_repository 'cassandra' do
+  uri 'http://www.apache.org/dist/cassandra/debian'
+  components %w[311x main]
+  distribution ''
+  arch 'amd64'
+  key 'A278B781FE4B2BDA'
+  keyserver 'hkp://ha.pool.sks-keyservers.net'
+  only_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
 package %w[cassandra cassandra-tools] do
   action %i[install upgrade]
+end
+
+cookbook_file '/etc/cassandra/jvm.options' do
+  source 'cassandra.jvm.options'
+  mode 0o644
+  owner 'root'
+  group 'root'
+  only_if { node['kernel']['machine'] == 'ppc64le' }
+  only_if { ::Dir.exist?("/etc/cassandra") }
 end
 
 service 'cassandra' do

--- a/cookbooks/travis_build_environment/recipes/ci_user.rb
+++ b/cookbooks/travis_build_environment/recipes/ci_user.rb
@@ -146,8 +146,13 @@ Array(node['travis_build_environment']['otp_releases']).each do |rel|
     only_if { ::File.exist?(local_archive) }
   end
 
+  kerl_build_cmd = "#{node['travis_build_environment']['kerl_path']} build #{rel} #{rel}"
+  if node['kernel']['machine'] == 'ppc64le'
+    kerl_build_cmd = "KERL_CONFIGURE_OPTIONS=--disable-hipe #{node['travis_build_environment']['kerl_path']} build #{rel} #{rel}"
+  end
+
   bash "build erlang #{rel}" do
-    code "#{node['travis_build_environment']['kerl_path']} build #{rel} #{rel}"
+    code kerl_build_cmd
 
     user node['travis_build_environment']['user']
     group node['travis_build_environment']['group']
@@ -202,6 +207,7 @@ Array(node['travis_build_environment']['elixir_versions']).each do |elixir|
       'HOME' => node['travis_build_environment']['home'],
       'USER' => node['travis_build_environment']['user']
     )
+    creates "#{dest}/bin/elixirc"
   end
 
   file "#{node['travis_build_environment']['home']}/.kiex/elixirs/elixir-#{elixir}.env" do

--- a/cookbooks/travis_build_environment/recipes/couchdb.rb
+++ b/cookbooks/travis_build_environment/recipes/couchdb.rb
@@ -7,6 +7,7 @@ apt_repository 'couchdb' do
   retries 2
   retry_delay 30
   action :add
+  not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
 package 'couchdb'

--- a/cookbooks/travis_build_environment/recipes/firefox.rb
+++ b/cookbooks/travis_build_environment/recipes/firefox.rb
@@ -30,4 +30,10 @@ ark 'firefox' do
   owner node['travis_build_environment']['user']
   group node['travis_build_environment']['group']
   has_binaries %w[firefox firefox-bin]
+  not_if { node['kernel']['machine'] == 'ppc64le' }
+end
+
+package %w[firefox] do
+  action %i[install upgrade]
+  only_if { node['kernel']['machine'] == 'ppc64le' }
 end

--- a/cookbooks/travis_build_environment/recipes/hhvm.rb
+++ b/cookbooks/travis_build_environment/recipes/hhvm.rb
@@ -1,8 +1,16 @@
+if node['kernel']['machine'] == 'ppc64le'
+  hhvm_uri = 'http://ppa.launchpad.net/ibmpackages/hhvm/ubuntu'
+  key = "E7D1FA0C"
+else
+  hhvm_uri = 'http://dl.hhvm.com/ubuntu'
+  key = 'http://dl.hhvm.com/conf/hhvm.gpg.key'
+end
+
 apt_repository 'hhvm-repository' do
-  uri 'http://dl.hhvm.com/ubuntu'
+  uri hhvm_uri
   distribution node['lsb']['codename']
   components ['main']
-  key 'http://dl.hhvm.com/conf/hhvm.gpg.key'
+  key key
   retries 2
   retry_delay 30
 end

--- a/cookbooks/travis_build_environment/recipes/mongodb.rb
+++ b/cookbooks/travis_build_environment/recipes/mongodb.rb
@@ -28,9 +28,16 @@ apt_repository 'mongodb-3.2' do
   key 'EA312927'
   retries 2
   retry_delay 30
+  not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
-package 'mongodb-org'
+package 'mongodb-org' do
+  not_if { node['kernel']['machine'] == 'ppc64le' }
+end
+
+package 'mongodb' do
+  only_if { node['kernel']['machine'] == 'ppc64le' }
+end
 
 service 'mongod' do
   action %i[stop disable]

--- a/cookbooks/travis_build_environment/recipes/mysql.rb
+++ b/cookbooks/travis_build_environment/recipes/mysql.rb
@@ -46,7 +46,7 @@ mysql_pkgs =  %w[
   mysql-server-5.6
   mysql-server-core-5.6
 ]
-if node['kernel']['machine'] == 'ppc64le' && node['lsb']['codename'] == 'xenial'
+if node['lsb']['codename'] == 'xenial'
   mysql_version = 5.7
   mysql_pkgs = %w[
     libmysqlclient-dev

--- a/cookbooks/travis_phantomjs/recipes/2.rb
+++ b/cookbooks/travis_phantomjs/recipes/2.rb
@@ -38,4 +38,21 @@ ark 'phantomjs' do
   checksum '785913935b14dfadf759e6f54fc6858eadab3c15b87f88a720b0942058b5b573'
   has_binaries %w[phantomjs]
   owner 'root'
+  not_if { node['kernel']['machine'] == 'ppc64le' }
+end
+
+ark 'phantomjs' do
+  url 'https://github.com/ibmsoe/phantomjs/releases/download/2.1.1/phantomjs-2.1.1-linux-ppc64.tar.bz2'
+  version '2.1.1'
+  has_binaries %w[phantomjs]
+  owner 'root'
+  only_if { node['kernel']['machine'] == 'ppc64le' }
+end
+
+cookbook_file '/etc/profile.d/phantomjs.sh' do
+  source 'etc/profile.d/phantomjs.sh'
+  owner 'root'
+  group 'root'
+  mode 0o644
+  only_if { node['kernel']['machine'] == 'ppc64le' }
 end


### PR DESCRIPTION
- Adds a new configuration file for cassandra jvm options
- Installs cassandra version 311x on pppc64le instead of 39x
- Builds erlang with kerl using --disable hipe option
- Installs couchdb version 1.6.0 on ppc64le/xenial instead of 1.6.1
- Installs firefox version 52.0.2 using apt on ppc64le/xenial instead of 54.0.1 installed via tarball
- Installs hhvm version 3.15.1 using ppa ibmpackages on ppc64le instead of 3.20.2
- Installs mongo version 1:2.6.10 using apt instead of mongodb-org 3.2
- Installs mysql-server version 5.7 on ppc64le/xenial instead of mysql-server version 5.6
- Installs phantomjs 2.1.1 on ppc64le instead of 2.0.0