### PR TITLE
Add mysql priveleges to travis user on mysql

### DIFF
--- a/cookbooks/travis_build_environment/recipes/mysql.rb
+++ b/cookbooks/travis_build_environment/recipes/mysql.rb
@@ -59,6 +59,11 @@ file mysql_users_passwords_sql do
     > CREATE USER 'travis'@'%' IDENTIFIED BY '';
     > SET PASSWORD FOR 'root'@'localhost' = PASSWORD('');
     > SET PASSWORD FOR 'root'@'127.0.0.1' = PASSWORD('');
+    > GRANT ALL PRIVILEGES ON *.* TO 'travis'@'%';
+    > CREATE USER 'travis'@'localhost' IDENTIFIED BY '';
+    > GRANT ALL PRIVILEGES ON *.* TO 'travis'@'localhost';
+    > CREATE USER 'travis'@'127.0.0.1' IDENTIFIED BY '';
+    > GRANT ALL PRIVILEGES ON *.* TO 'travis'@'127.0.0.1';
   EOF
 end
 


### PR DESCRIPTION
Please make sure you cover the following points:

## What is the problem that this PR is trying to fix?
https://github.com/travis-ci/packer-templates/issues/470

## What approach did you choose and why?
[Inline permissions in mysql recipe](https://github.com/travis-ci/travis-cookbooks/pull/881/files#diff-500cc5d1e580911aa20552039d71c9fbR62) previously [defined in a template on Precise](https://github.com/travis-ci/travis-cookbooks/blob/precise-stable/ci_environment/mysql/templates/default/grants.sql.erb#L22)

## How can you test this?
Testing with packer-build pipeline, and test the `edge` images
Paired w/ @meatballhat , who wrote specs to assert mysql `travis` user priveleges in 
https://github.com/travis-ci/packer-templates/pull/479

( What feedback would you like?)

