### PR TITLE
add mercurial to list of default pip pkgs

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -88,7 +88,7 @@ default['travis_build_environment']['python_aliases'] = {
 }
 
 default['travis_build_environment']['pip']['packages'] = {
-  'default' => %w[nose pytest mock wheel],
+  'default' => %w[nose pytest mercurial mock wheel],
   '2.7' => %w[numpy],
   '3.6' => %w[numpy]
 }


### PR DESCRIPTION
Please make sure you cover the following points:

## What is the problem that this PR is trying to fix?
https://github.com/travis-ci/packer-templates/issues/480
https://github.com/travis-ci/travis-ci/issues/8202#issuecomment-322637202

## What approach did you choose and why?
Adding `mercurial` to list of default pip packages for all Trusty images as all trusty images expect it
https://github.com/travis-ci/packer-templates/search?utf8=%E2%9C%93&q=mercurial&type=

## How can you test this?
a new packer build pipeline with this fix is being kicked off here: 
https://travis-ci.org/travis-infrastructure/packer-build/builds/265122748
if that image passes, we'll test `which hg` and `pip freeze | grep mercurial` on the build image itself to test for mercurial's presence

(4. What feedback would you like?)
