### PR TITLE
Add env variables to improve jvm performance and memory allocation

### DIFF
--- a/cookbooks/travis_java/templates/default/travis-java.sh.erb
+++ b/cookbooks/travis_java/templates/default/travis-java.sh.erb
@@ -4,7 +4,9 @@ export JDK_SWITCHER_DEFAULT="<%= @jdk_switcher_default -%>"
 <% end -%>
 <% unless @jvm_name.nil? || @jvm_name.empty? -%>
 export JAVA_HOME="<%= @jvm_base_dir -%>/<%= @jvm_name -%>"
+export _JAVA_OPTIONS="-Xmx2048m -Xms512m -XX:MaxPermSize=768m"
 <% end -%>
 if [ -f "<%= @jdk_switcher_path -%>" ]; then
   . "<%= @jdk_switcher_path -%>"
 fi
+export MALLOC_ARENA_MAX=2

--- a/cookbooks/travis_java/templates/default/travis-java.sh.erb
+++ b/cookbooks/travis_java/templates/default/travis-java.sh.erb
@@ -4,7 +4,7 @@ export JDK_SWITCHER_DEFAULT="<%= @jdk_switcher_default -%>"
 <% end -%>
 <% unless @jvm_name.nil? || @jvm_name.empty? -%>
 export JAVA_HOME="<%= @jvm_base_dir -%>/<%= @jvm_name -%>"
-export _JAVA_OPTIONS="-Xmx2048m -Xms512m -XX:MaxPermSize=768m"
+export _JAVA_OPTIONS="-Xmx2048m -Xms512m"
 <% end -%>
 if [ -f "<%= @jdk_switcher_path -%>" ]; then
   . "<%= @jdk_switcher_path -%>"


### PR DESCRIPTION
Please make sure you cover the following points:

### What is the problem that this PR is trying to fix?
https://github.com/travis-pro/team-blue/issues/728
and more specifically: https://github.com/travis-pro/team-blue/issues/728#issuecomment-322746660

### What approach did you choose and why?
Add env variables to optimize jvm's memory usage, as suggested in the comment above.
I thought the travis_java cookbook is a good place for this since it's less generic and it is included in all images we're building (including connie, which was the main one our users were complaining about):

`cookbooks/travis_ci_amethyst/recipes/default.rb:include_recipe 'travis_java'
cookbooks/travis_ci_connie/recipes/default.rb:include_recipe 'travis_java'
cookbooks/travis_ci_cookiecat/recipes/default.rb:include_recipe 'travis_java'
cookbooks/travis_ci_garnet/recipes/default.rb:include_recipe 'travis_java'
cookbooks/travis_ci_stevonnie/recipes/default.rb:include_recipe 'travis_java'
cookbooks/travis_ci_sugilite/recipes/default.rb:include_recipe 'travis_java' `

### How can you test this?
Build the images and check the presence of the new variables in a debug build.
Run a previously failing build on connie and see that it passes (Example: https://travis-ci.org/comdata/HomeAutomation/builds/255176816)

### What feedback would you like?
Is travis_java the best place for these changes?
We also configure this as part of [travis_sbt_extras](https://github.com/travis-ci/travis-cookbooks/blob/master/cookbooks/travis_sbt_extras/templates/default/jvmopts.erb) - should this be removed now?
