### PR TITLE
Update docker to 17.06.1 and docker-compose to 1.15.0

### DIFF
--- a/cookbooks/travis_docker/attributes/default.rb
+++ b/cookbooks/travis_docker/attributes/default.rb
@@ -1,11 +1,15 @@
-default['travis_docker']['version'] = '17.03.1~ce-0~ubuntu-trusty'
+# Note: The docker-ce package version strings have been known to diverge between
+# Trusty and Xenial. When updating check the version exists in both of:
+# https://download.docker.com/linux/ubuntu/dists/trusty/stable/binary-amd64/Packages
+# https://download.docker.com/linux/ubuntu/dists/xenial/stable/binary-amd64/Packages
+default['travis_docker']['version'] = '17.06.1~ce-0~ubuntu'
 default['travis_docker']['users'] = %w[travis]
-default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.13.0/docker-compose-Linux-x86_64'
-default['travis_docker']['compose']['sha256sum'] = '0d8af4d3336b0b41361c06ff213be5c42e2247beb746dbc597803e862af127e8'
+default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.15.0/docker-compose-Linux-x86_64'
+default['travis_docker']['compose']['sha256sum'] = 'acfa66dba77dac9635ff9b195ccea81768eb009ce9c9f1181c000eb95effb963'
 default['travis_docker']['update_grub'] = true
-default['travis_docker']['binary']['url'] = 'https://download.docker.com/linux/static/stable/x86_64/docker-17.03.1-ce.tgz'
-default['travis_docker']['binary']['version'] = '17.03.1-ce'
-default['travis_docker']['binary']['checksum'] = '3e070e7b34e99cf631f44d0ff5cf9a127c0b8af5c53dfc3e1fce4f9615fbf603'
+default['travis_docker']['binary']['url'] = 'https://download.docker.com/linux/static/stable/x86_64/docker-17.06.1-ce.tgz'
+default['travis_docker']['binary']['version'] = '17.06.1-ce'
+default['travis_docker']['binary']['checksum'] = 'e35fe12806eadbb7eb8aa63e3dfb531bda5f901cd2c14ac9cdcd54df6caed697'
 default['travis_docker']['binary']['binaries'] = %w[
   docker
   docker-containerd


### PR DESCRIPTION
The 17.06 series is the latest 'stable' release after 17.03.

For changelogs see:
https://docs.docker.com/release-notes/docker-ce/#17061-ce-2017-08-15
https://docs.docker.com/release-notes/docker-compose/#1150-2017-07-26

As of the docker-ce `17.06.1~ce-0~ubuntu` release, the package name no longer includes the string `trusty`, so is identical across both Trusty and Xenial. As such, once this PR is merged, the Xenial override in packer-templates can be removed:
https://github.com/travis-ci/packer-templates/blob/9c6875413a5395c4c4dbfcbc1eeb7569e3e35b1b/cookbooks/travis_ci_stevonnie/attributes/default.rb#L3

Should the Trusty and Xenial versions ever diverge again, IMO it would be best to add the conditional to travis-cookbooks rather than overriding in packer-templates.