### PR TITLE
Set innodb_flush_log_at_trx_commit=0 to improve MySQL performance

### DIFF
--- a/cookbooks/travis_build_environment/recipes/mysql.rb
+++ b/cookbooks/travis_build_environment/recipes/mysql.rb
@@ -67,6 +67,13 @@ file mysql_users_passwords_sql do
   EOF
 end
 
+template "/etc/mysql/conf.d/innodb_flush_log_at_trx_commit.cnf" do
+  source 'root/innodb_flush_log_at_trx_commit.cnf.erb'
+  owner 'root'
+  group 'root'
+  mode 0o640
+end
+
 template "/etc/mysql/conf.d/performance-schema.cnf" do
   source 'root/performance-schema.cnf.erb'
   owner 'root'

--- a/cookbooks/travis_build_environment/templates/default/root/innodb_flush_log_at_trx_commit.cnf.erb
+++ b/cookbooks/travis_build_environment/templates/default/root/innodb_flush_log_at_trx_commit.cnf.erb
@@ -1,0 +1,2 @@
+[mysqld]
+innodb_flush_log_at_trx_commit=0


### PR DESCRIPTION
Fix #887 