### PR TITLE
Skip adding `-Xcext.enabled=false` to JRUBY_OPTS

### DIFF
--- a/cookbooks/travis_build_environment/files/default/travis_environment_ruby.bash
+++ b/cookbooks/travis_build_environment/files/default/travis_environment_ruby.bash
@@ -10,10 +10,6 @@ JRUBY_OPTS="$JRUBY_OPTS --client"
 # Enable the equivalent of the C1 compiler on newer versions of OpenJDK
 JRUBY_OPTS="$JRUBY_OPTS -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1"
 
-# Disable C extensions, as running them in production on JRuby is a bad idea but
-# developers often do not realize they depend on C extensions
-JRUBY_OPTS="$JRUBY_OPTS -Xcext.enabled=false"
-
 # Bump stack size to 2 MB
 JRUBY_OPTS="$JRUBY_OPTS -J-Xss2m"
 


### PR DESCRIPTION
This flag is no longer recognized by JRuby 9.0.x

There is a chance where JRuby 1.7.x behaves erratically, but the chances
are that it is a minor issue, and 1.7.x is EOL soon.

Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?

Eradicate unsightly warnings (https://travis-ci.org/BanzaiMan/travis_production_test/builds/275026245#L558):

    jruby: warning: unknown property jruby.cext.enabled

2. What approach did you choose and why?

This should be removed from all images.

3. How can you test this?

Boot a job, execute a `jruby` command. Confirm that the warning above is no longer printed.

(4. What feedback would you like?)
