### PR TITLE
Add enchant to phpbuild options

### DIFF
--- a/ci_environment/phpbuild/templates/default/default_configure_options.erb
+++ b/ci_environment/phpbuild/templates/default/default_configure_options.erb
@@ -48,3 +48,4 @@
 --enable-dba
 --with-cdb
 --with-inifile
+--with-enchant=/usr


### PR DESCRIPTION
This PR addresses the [issue](https://github.com/travis-ci/travis-ci/issues/8473) when trying to use the PHP [enchant](http://php.net/manual/en/enchant.installation.php) library. Since this seems like a compile-time only configuration option, it would need to be added to the phpbuild options.  Feedback is welcome as I am new to this project and usnsure of any other way to get enchant configured on a travis box.