### PR TITLE
Prepend `$PYENV_ROOT/bin` to `$PATH`

### DIFF
--- a/cookbooks/travis_build_environment/templates/default/pyenv.bash.erb
+++ b/cookbooks/travis_build_environment/templates/default/pyenv.bash.erb
@@ -1,5 +1,5 @@
 # Managed by Chef on <%= node.name %>! :heart_eyes_cat:
-export PATH="$PATH:<%= @pyenv_root %>/bin"
+export PATH="<%= @pyenv_root %>/bin:$PATH"
 export PYENV_ROOT="<%= @pyenv_root %>"
 <%# Configure python-build for consistent build options %>
 <% @build_environment.each do |key, value| %>


### PR DESCRIPTION
See https://github.com/pyenv/pyenv#basic-github-checkout

Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?

`pyenv` appears to be ill-configured.

2. What approach did you choose and why?

Read https://github.com/pyenv/pyenv#basic-github-checkout, which suggests that `$PYENV_ROOT/bin` should be prepended to `$PATH`.

3. How can you test this?

I asked for confirmation in https://github.com/travis-ci/travis-ci/issues/8363#issuecomment-335031959.

(4. What feedback would you like?)
