### PR TITLE
Updates for power/xenial, identified while testing sardonyx stack

### DIFF
--- a/cookbooks/travis_build_environment/recipes/mongodb.rb
+++ b/cookbooks/travis_build_environment/recipes/mongodb.rb
@@ -36,9 +36,17 @@ package 'mongodb-org' do
 end
 
 package 'mongodb' do
+  notifies :stop, 'service[mongodb]', :immediately
+  notifies :disable, 'service[mongodb]', :immediately
+  only_if { node['kernel']['machine'] == 'ppc64le' }
+end
+
+service 'mongodb' do
+  action :nothing
   only_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
 service 'mongod' do
   action %i[stop disable]
+  not_if { node['kernel']['machine'] == 'ppc64le' }
 end

--- a/cookbooks/travis_build_environment/recipes/mysql.rb
+++ b/cookbooks/travis_build_environment/recipes/mysql.rb
@@ -81,6 +81,8 @@ mysql_user_passwords_sql_content = [
 
 if mysql_version < 5.7
   mysql_user_passwords_sql_content << "SET PASSWORD FOR 'root'@'127.0.0.1' = PASSWORD('')"
+elsif mysql_version == 5.7
+  mysql_user_passwords_sql_content << "UPDATE mysql.user SET plugin = 'mysql_native_password' WHERE User = 'root'; FLUSH PRIVILEGES;"
 end
 
 file mysql_users_passwords_sql do
@@ -91,14 +93,14 @@ template "/etc/mysql/conf.d/innodb_flush_log_at_trx_commit.cnf" do
   source 'root/innodb_flush_log_at_trx_commit.cnf.erb'
   owner 'root'
   group 'root'
-  mode 0o640
+  mode 0o644
 end
 
 template "/etc/mysql/conf.d/performance-schema.cnf" do
   source 'root/performance-schema.cnf.erb'
   owner 'root'
   group 'root'
-  mode 0o640
+  mode 0o644
 end
 
 template "#{node['travis_build_environment']['home']}/.my.cnf" do


### PR DESCRIPTION
Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?
- Updates service name for mongodb for power
- Updates default auth_socket plugin for mysql 5.7 to mysql_native_password
- Updates permission of mysql configuration file, else the test suit fails

2. What approach did you choose and why?

3. How can you test this?

(4. What feedback would you like?)
Please review and let me know your comments