### PR TITLE
Add default['travis_docker']['ppc64le']['apt']['url'] back 

### DIFF
--- a/cookbooks/travis_docker/attributes/default.rb
+++ b/cookbooks/travis_docker/attributes/default.rb
@@ -3,6 +3,7 @@
 # https://download.docker.com/linux/ubuntu/dists/trusty/stable/binary-amd64/Packages
 # https://download.docker.com/linux/ubuntu/dists/xenial/stable/binary-amd64/Packages
 default['travis_docker']['version'] = '17.09.0~ce-0~ubuntu'
+default['travis_docker']['ppc64le']['apt']['url'] = 'http://ftp.unicamp.br/pub/ppc64el/ubuntu/16_04/docker-17.06.1-ce-ppc64el/'
 default['travis_docker']['users'] = %w[travis]
 default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.15.0/docker-compose-Linux-x86_64'
 default['travis_docker']['compose']['sha256sum'] = 'acfa66dba77dac9635ff9b195ccea81768eb009ce9c9f1181c000eb95effb963'


### PR DESCRIPTION
Add `default['travis_docker']['ppc64le']['apt']['url']` back to `cookbooks/travis_docker/attributes/default.rb` because of [this test failure](https://travis-ci.org/travis-infrastructure/packer-build/jobs/293737109#L683).

Partial revert of https://github.com/travis-ci/travis-cookbooks/pull/928
https://github.com/travis-ci/travis-cookbooks/pull/928#pullrequestreview-71698883 should be addressed in a future PR.