### PR TITLE
Power Xenial changes for Neo4j and PostgreSQL 

### DIFF
--- a/cookbooks/travis_build_environment/files/default/neo4j.pkla
+++ b/cookbooks/travis_build_environment/files/default/neo4j.pkla
@@ -1,0 +1,6 @@
+[neo4j service]
+Identity=unix-user:travis
+Action=org.freedesktop.systemd1.manage-units
+ResultAny=yes
+ResultInactive=yes
+ResultActive=yes

--- a/cookbooks/travis_build_environment/recipes/neo4j.rb
+++ b/cookbooks/travis_build_environment/recipes/neo4j.rb
@@ -11,6 +11,14 @@ ark 'neo4j' do
   strip_components 1
 end
 
+cookbook_file '/etc/polkit-1/localauthority/50-local.d/neo4j.pkla' do
+  source 'neo4j.pkla'
+  owner 'root'
+  group 'root'
+  mode  0o644
+  only_if { node['lsb']['codename'] == 'xenial' }
+end
+
 template '/etc/init.d/neo4j' do
   source 'etc-init.d-neo4j.sh.erb'
   owner node['travis_build_environment']['user']

--- a/cookbooks/travis_postgresql/recipes/ci_server.rb
+++ b/cookbooks/travis_postgresql/recipes/ci_server.rb
@@ -25,7 +25,7 @@ if !node['travis_postgresql']['superusers'].to_a.empty? && !::File.exist?(create
 end
 
 service 'postgresql' do
-  action :stop
+  action %i[disable stop]
 end
 
 template '/etc/init.d/postgresql' do
@@ -33,6 +33,18 @@ template '/etc/init.d/postgresql' do
   owner 'root'
   group 'root'
   mode 0o755
+end
+
+file '/lib/systemd/system/postgresql.service' do
+  action :delete
+  notifies :run, 'execute[daemon-reload]', :immediately
+  only_if { node['lsb']['codename'] == 'xenial' }
+end
+
+execute 'daemon-reload' do
+  command 'systemctl daemon-reload'
+  action :nothing
+  only_if { node['lsb']['codename'] == 'xenial' }
 end
 
 Array(

--- a/cookbooks/travis_postgresql/recipes/ci_server.rb
+++ b/cookbooks/travis_postgresql/recipes/ci_server.rb
@@ -37,12 +37,11 @@ end
 
 file '/lib/systemd/system/postgresql.service' do
   action :delete
-  notifies :run, 'execute[daemon-reload]', :immediately
+  notifies :run, 'execute[systemctl daemon-reload]', :immediately
   only_if { node['lsb']['codename'] == 'xenial' }
 end
 
-execute 'daemon-reload' do
-  command 'systemctl daemon-reload'
+execute 'systemctl daemon-reload' do
   action :nothing
   only_if { node['lsb']['codename'] == 'xenial' }
 end


### PR DESCRIPTION
Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?
- Adds a policykit rule to allow neo4j to be started by travis user without sudo on xenial systems
- Removes systemd file for PostgreSQL to use init.d file for starting PostgreSQL service on xenial

2. What approach did you choose and why?

3. How can you test this?

(4. What feedback would you like?)
- Adding .pkla file had a downside that **all** the services now can be started without sudo by travis user, let me know if instead prefixing sudo while starting neo4j can be considered as an option
- Is it okay to delete the default systemd file for PostgreSQL or instead adding a new systemd file for PostgreSQL should be considered .