### PR TITLE
Always install the latest stable version of Yarn

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -273,9 +273,8 @@ default['travis_build_environment']['shellcheck_binaries'] = %w[shellcheck]
 default['travis_build_environment']['shfmt_url'] = 'https://github.com/mvdan/sh/releases/download/v2.0.0/shfmt_v2.0.0_linux_amd64'
 default['travis_build_environment']['shfmt_checksum'] = 'f21ec3c37b9ece776a737629650adcb79f7b529026b967432a8a2c2b40dcabe0'
 
-default['travis_build_environment']['yarn_url'] = 'https://yarnpkg.com/downloads/0.27.5/yarn-v0.27.5.tar.gz'
-default['travis_build_environment']['yarn_version'] = '0.27.5'
-default['travis_build_environment']['yarn_checksum'] = 'f0f3510246ee74eb660ea06930dcded7b684eac2593aa979a7add84b72517968'
+default['travis_build_environment']['yarn_url'] = 'https://yarnpkg.com/latest.tar.gz'
+default['travis_build_environment']['yarn_version'] = 'latest'
 default['travis_build_environment']['yarn_binaries'] = %w[
   bin/yarn
   bin/yarn.js

--- a/cookbooks/travis_build_environment/recipes/yarn.rb
+++ b/cookbooks/travis_build_environment/recipes/yarn.rb
@@ -1,7 +1,6 @@
 ark 'yarn' do
   url node['travis_build_environment']['yarn_url']
   version node['travis_build_environment']['yarn_version']
-  checksum node['travis_build_environment']['yarn_checksum']
   strip_components 1
   has_binaries node['travis_build_environment']['yarn_binaries']
 end


### PR DESCRIPTION
1. What is the problem that this PR is trying to fix?

The Yarn project is frequently releasing updates, which causes many requests for the pre-installed version to be bumped. With this PR the latest version of yarn is always installed at time of image creation. 

Fixes #931 and travis-ci/travis-ci#7566.

2. What approach did you choose and why?

Whilst yarn does have their own APT repo (which might make more sense if pulling `latest`), it's a more disruptive change than just adjusting the existing URL.

Ark supports omitting the `checksum` property, which we have to do since it will be constantly changing. The `version` property is only used for determining the install location name (which is then symlinked back to the non-suffixed name), so doesn't need to be a traditional numeric version string.

3. How can you test this?

CI.

(I feel like this question might be best worded "does this change require any additional testing other than CI?" or similar)

(4. What feedback would you like?)