### PR TITLE
Update checksum for docker binary archive

### DIFF
--- a/cookbooks/travis_docker/attributes/default.rb
+++ b/cookbooks/travis_docker/attributes/default.rb
@@ -9,7 +9,7 @@ default['travis_docker']['compose']['sha256sum'] = 'acfa66dba77dac9635ff9b195cce
 default['travis_docker']['update_grub'] = true
 default['travis_docker']['binary']['url'] = "https://download.docker.com/linux/static/stable/#{node['kernel']['machine']}/docker-17.09.0-ce.tgz"
 default['travis_docker']['binary']['version'] = '17.09.0-ce'
-default['travis_docker']['binary']['checksum'] = 'e9902c16a81b67830bf361074e5ffc3333bf48a3e37e2ef0544fd9955bd3f1f7'
+default['travis_docker']['binary']['checksum'] = 'a9e90a73c3cdfbf238f148e1ec0eaff5eb181f92f35bdd938fd7dab18e1c4647'
 if node['kernel']['machine'] == 'ppc64le'
   default['travis_docker']['binary']['checksum'] = 'f00d4cefd392893241e5ae3be292ade0e9076cbba6fde56e731ae5002558b82a'
 end


### PR DESCRIPTION
The checksum added by #928 doesn't match that for:
https://download.docker.com/linux/static/stable/x86_64/docker-17.09.0-ce.tgz

...so was resulting in packer-build failures:
https://travis-ci.org/travis-infrastructure/packer-build/jobs/298683570#L1834

Fixes #936.