### PR TITLE
Fix maven URL

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -238,7 +238,7 @@ default['travis_build_environment']['lein_url'] = 'https://raw.githubusercontent
 default['travis_build_environment']['sysctl_kernel_shmmax'] = 45_794_432
 default['travis_build_environment']['sysctl_disable_ipv6'] = true
 
-default['travis_build_environment']['maven_url'] = 'https://www.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.2-bin.tar.gz'
+default['travis_build_environment']['maven_url'] = 'https://www.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz'
 default['travis_build_environment']['maven_version'] = '3.5.2'
 default['travis_build_environment']['maven_checksum'] = '707b1f6e390a65bde4af4cdaf2a24d45fc19a6ded00fff02e91626e3e42ceaff'
 default['travis_build_environment']['maven_binaries'] = %w[


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The maven URL wasn't updated correctly and was causing image builds to fail: https://travis-ci.org/travis-infrastructure/packer-build/jobs/299244554

Also fixes https://github.com/travis-ci/travis-cookbooks/issues/933 and https://github.com/travis-pro/team-blue/issues/797

## What approach did you choose and why?
Use the correct URL for version 3.5.2.

## How can you test this?
✅ Check that the image builds successfully.
✅ Check that the new URL is valid.