### PR TITLE
Update docker-compose from 1.15.0 to 1.17.1

### DIFF
--- a/cookbooks/travis_docker/attributes/default.rb
+++ b/cookbooks/travis_docker/attributes/default.rb
@@ -4,8 +4,8 @@
 # https://download.docker.com/linux/ubuntu/dists/xenial/stable/binary-amd64/Packages
 default['travis_docker']['version'] = '17.09.0~ce-0~ubuntu'
 default['travis_docker']['users'] = %w[travis]
-default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.15.0/docker-compose-Linux-x86_64'
-default['travis_docker']['compose']['sha256sum'] = 'acfa66dba77dac9635ff9b195ccea81768eb009ce9c9f1181c000eb95effb963'
+default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.17.1/docker-compose-Linux-x86_64'
+default['travis_docker']['compose']['sha256sum'] = 'db0a7b79d195dc021461d5628a8d53eeb2e556d2548b764770fccabb0a319dd8'
 default['travis_docker']['update_grub'] = true
 default['travis_docker']['binary']['url'] = "https://download.docker.com/linux/static/stable/#{node['kernel']['machine']}/docker-17.09.0-ce.tgz"
 default['travis_docker']['binary']['version'] = '17.09.0-ce'


### PR DESCRIPTION
Updates docker-compose to the latest release:
https://docs.docker.com/release-notes/docker-compose/
(The 1.17.1 release notes don't yet appear on that page, for those [see here](https://github.com/docker/compose/releases/tag/1.17.1))

[Connie build](https://travis-ci.org/travis-infrastructure/packer-build/builds/299806455): ✅ 

(Didn't test the other trusty images, since there are no deviations docker-compose-wise, and skipped the Xenial images since they are already failing due to travis-ci/packer-templates#544).