### PR TITLE
Update phantomjs to version 2.1.1

### DIFF
--- a/cookbooks/travis_phantomjs/recipes/2.rb
+++ b/cookbooks/travis_phantomjs/recipes/2.rb
@@ -27,10 +27,20 @@ package %w[
 ]
 
 ark 'phantomjs' do
+  url 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2'
+  version '2.1.1'
+  checksum '86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f'
+  has_binaries %w[phantomjs]
+  owner 'root'
+  not_if { node['kernel']['machine'] == 'ppc64le' }
+end
+
+ark 'phantomjs' do
   url 'https://github.com/ibmsoe/phantomjs/releases/download/2.1.1/phantomjs-2.1.1-linux-ppc64.tar.bz2'
   version '2.1.1'
   has_binaries %w[phantomjs]
   owner 'root'
+  only_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
 cookbook_file '/etc/profile.d/phantomjs.sh' do
@@ -38,4 +48,5 @@ cookbook_file '/etc/profile.d/phantomjs.sh' do
   owner 'root'
   group 'root'
   mode 0o644
+  only_if { node['kernel']['machine'] == 'ppc64le' }
 end

--- a/cookbooks/travis_phantomjs/recipes/2.rb
+++ b/cookbooks/travis_phantomjs/recipes/2.rb
@@ -27,26 +27,10 @@ package %w[
 ]
 
 ark 'phantomjs' do
-  url ::File.join(
-    'https://s3.amazonaws.com/travis-phantomjs',
-    node['platform'],
-    node['platform_version'],
-    node['kernel']['machine'],
-    'phantomjs-2.0.0.tar.bz2'
-  )
-  version '2.0.0'
-  checksum '785913935b14dfadf759e6f54fc6858eadab3c15b87f88a720b0942058b5b573'
-  has_binaries %w[phantomjs]
-  owner 'root'
-  not_if { node['kernel']['machine'] == 'ppc64le' }
-end
-
-ark 'phantomjs' do
   url 'https://github.com/ibmsoe/phantomjs/releases/download/2.1.1/phantomjs-2.1.1-linux-ppc64.tar.bz2'
   version '2.1.1'
   has_binaries %w[phantomjs]
   owner 'root'
-  only_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
 cookbook_file '/etc/profile.d/phantomjs.sh' do
@@ -54,5 +38,4 @@ cookbook_file '/etc/profile.d/phantomjs.sh' do
   owner 'root'
   group 'root'
   mode 0o644
-  only_if { node['kernel']['machine'] == 'ppc64le' }
 end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
https://github.com/travis-pro/team-blue/issues/730 and https://github.com/travis-ci/travis-cookbooks/issues/910
## What approach did you choose and why?
Switch from 2.0.0 to 2.1.1
## How can you test this?
✅  Check that new images can be successfully built: https://travis-ci.org/travis-infrastructure/packer-build/builds/300225167
✅  Check phantomjs version on the new images: https://travis-ci.org/bogdanap/travis_production_test/builds/300250700
