### PR TITLE
Fixed typo in community-cookbooks/android-sdk/files/default/android-wait-for-emulator

### DIFF
--- a/community-cookbooks/android-sdk/files/default/android-wait-for-emulator
+++ b/community-cookbooks/android-sdk/files/default/android-wait-for-emulator
@@ -14,7 +14,7 @@ until [[ "$bootanim" =~ "stopped" ]]; do
     || "$bootanim" =~ "running" ]]; then
     let "failcounter += 1"
     echo "Waiting for emulator to start"
-    if [[ $failcounter -gt timeout_in_sec ]]; then
+    if [[ $failcounter -gt $timeout_in_sec ]]; then
       echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
       exit 1
     fi


### PR DESCRIPTION
Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?
- It seems that there is missing dolar sign when comparing timeout
2. What approach did you choose and why?

3. How can you test this?
- I tested on my jenkins instance
(4. What feedback would you like?)
