### PR TITLE
Upgrade neo4j to version 3.2.7

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -252,9 +252,9 @@ default['travis_build_environment']['maven_binaries'] = %w[
 
 default['travis_build_environment']['neo4j']['service_enabled'] = false
 default['travis_build_environment']['neo4j']['jvm_heap'] = '128m'
-default['travis_build_environment']['neo4j_url'] = 'https://neo4j.com/artifact.php?name=neo4j-community-3.2.1-unix.tar.gz'
-default['travis_build_environment']['neo4j_version'] = '3.2.1'
-default['travis_build_environment']['neo4j_checksum'] = '24fd6a704e0d80c4b4f9a3d17ce0db23f258a8cdcfa1eb28d7803b7d1811ee96'
+default['travis_build_environment']['neo4j_url'] = 'https://neo4j.com/artifact.php?name=neo4j-community-3.2.7-unix.tar.gz'
+default['travis_build_environment']['neo4j_version'] = '3.2.7'
+default['travis_build_environment']['neo4j_checksum'] = '7f347196a1f2026f8daa9ee045d3fbb404d961dd81b3a8363132aaaf60cf316f'
 
 default['travis_build_environment']['mercurial_install_type'] = 'ppa'
 if node['kernel']['machine'] == 'ppc64le'


### PR DESCRIPTION
 ## What is the problem that this PR is trying to fix?
Image builds were failing due to a ChecksumMistmatch on the Neo4j package: https://travis-ci.org/travis-infrastructure/packer-build/builds/301859017

## What approach did you choose and why?
Decided to take the opportunity and upgrade the package to the next minor release. 

## How can you test this?
Image builds are green again: https://travis-ci.org/travis-infrastructure/packer-build/builds/301956423?utm_source=email&utm_medium=notification

## What kind of feedback would you like?
 Should I have upgraded to the very latest version, which is 3.3.0? (it seemed to include a lot of [changes](https://github.com/neo4j/neo4j/wiki/Neo4j-3.3-changelog) and I didn't want to rock the boat too hard)
