### PR TITLE
Add i386 architecture

### DIFF
--- a/cookbooks/travis_build_environment/recipes/apt.rb
+++ b/cookbooks/travis_build_environment/recipes/apt.rb
@@ -84,6 +84,10 @@ execute 'gencaches for travis_build_environment::apt' do
   command 'apt-cache gencaches'
 end
 
+execute 'add i386 architecture for travis_build_environment::apt' do
+  command 'dpkg --add-architecture i386'
+end
+
 execute 'apt-get update for travis_build_environment::apt' do
   command 'apt-get update'
 end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Add the i386 architecture to apt

## What approach did you choose and why?
Add the i386 architecture to apt

## How can you make sure the change works as expected?
https://github.com/travis-ci/packer-templates/pull/551
https://travis-ci.org/travis-infrastructure/packer-build/jobs/303042391#L4127

## Would you like any additional feedback?
