### PR TITLE
Update HHVM GPG key

### DIFF
--- a/cookbooks/travis_build_environment/recipes/hhvm.rb
+++ b/cookbooks/travis_build_environment/recipes/hhvm.rb
@@ -3,7 +3,7 @@ if node['kernel']['machine'] == 'ppc64le'
   key = "E7D1FA0C"
 else
   hhvm_uri = 'http://dl.hhvm.com/ubuntu'
-  key = 'http://dl2.hhvm.com/conf/hhvm.gpg.key'
+  key = 'https://dl2.hhvm.com/conf/hhvm.gpg.key'
 end
 
 apt_repository 'hhvm-repository' do

--- a/cookbooks/travis_build_environment/recipes/hhvm.rb
+++ b/cookbooks/travis_build_environment/recipes/hhvm.rb
@@ -3,7 +3,6 @@ if node['kernel']['machine'] == 'ppc64le'
   key = "E7D1FA0C"
 else
   hhvm_uri = 'https://dl.hhvm.com/ubuntu'
-  keyserver = 'keyserver.ubuntu.com'
   key = ['0x5a16e7281be7a449', '0xB4112585D386EB94']
 end
 
@@ -12,6 +11,7 @@ apt_repository 'hhvm-repository' do
   distribution node['lsb']['codename']
   components ['main']
   arch 'amd64'
+  keyserver 'keyserver.ubuntu.com'
   key key
   retries 2
   retry_delay 30

--- a/cookbooks/travis_build_environment/recipes/hhvm.rb
+++ b/cookbooks/travis_build_environment/recipes/hhvm.rb
@@ -2,8 +2,8 @@ if node['kernel']['machine'] == 'ppc64le'
   hhvm_uri = 'http://ppa.launchpad.net/ibmpackages/hhvm/ubuntu'
   key = "E7D1FA0C"
 else
-  hhvm_uri = 'http://dl.hhvm.com/ubuntu'
-  key = 'https://dl2.hhvm.com/conf/hhvm.gpg.key'
+  hhvm_uri = 'https://dl.hhvm.com/ubuntu'
+  key = ['https://dl.hhvm.com/conf/hhvm.gpg.key', 'https://dl2.hhvm.com/conf/hhvm.gpg.key']
 end
 
 apt_repository 'hhvm-repository' do

--- a/cookbooks/travis_build_environment/recipes/hhvm.rb
+++ b/cookbooks/travis_build_environment/recipes/hhvm.rb
@@ -3,7 +3,7 @@ if node['kernel']['machine'] == 'ppc64le'
   key = "E7D1FA0C"
 else
   hhvm_uri = 'http://dl.hhvm.com/ubuntu'
-  key = 'http://dl.hhvm.com/conf/hhvm.gpg.key'
+  key = 'http://dl2.hhvm.com/conf/hhvm.gpg.key'
 end
 
 apt_repository 'hhvm-repository' do

--- a/cookbooks/travis_build_environment/recipes/hhvm.rb
+++ b/cookbooks/travis_build_environment/recipes/hhvm.rb
@@ -3,7 +3,7 @@ if node['kernel']['machine'] == 'ppc64le'
   key = "E7D1FA0C"
 else
   hhvm_uri = 'https://dl.hhvm.com/ubuntu'
-  key = %w(0x5a16e7281be7a449 0xB4112585D386EB94)
+  key = %w[0x5a16e7281be7a449 0xB4112585D386EB94]
 end
 
 apt_repository 'hhvm-repository' do

--- a/cookbooks/travis_build_environment/recipes/hhvm.rb
+++ b/cookbooks/travis_build_environment/recipes/hhvm.rb
@@ -3,13 +3,15 @@ if node['kernel']['machine'] == 'ppc64le'
   key = "E7D1FA0C"
 else
   hhvm_uri = 'https://dl.hhvm.com/ubuntu'
-  key = ['https://dl.hhvm.com/conf/hhvm.gpg.key', 'https://dl2.hhvm.com/conf/hhvm.gpg.key']
+  keyserver = 'keyserver.ubuntu.com'
+  key = ['0x5a16e7281be7a449', '0xB4112585D386EB94']
 end
 
 apt_repository 'hhvm-repository' do
   uri hhvm_uri
   distribution node['lsb']['codename']
   components ['main']
+  arch 'amd64'
   key key
   retries 2
   retry_delay 30

--- a/cookbooks/travis_build_environment/recipes/hhvm.rb
+++ b/cookbooks/travis_build_environment/recipes/hhvm.rb
@@ -3,7 +3,7 @@ if node['kernel']['machine'] == 'ppc64le'
   key = "E7D1FA0C"
 else
   hhvm_uri = 'https://dl.hhvm.com/ubuntu'
-  key = ['0x5a16e7281be7a449', '0xB4112585D386EB94']
+  key = %w(0x5a16e7281be7a449 0xB4112585D386EB94)
 end
 
 apt_repository 'hhvm-repository' do


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Image builds are currently broken due to the HHVM key being rotated: https://hhvm.com/blog/2017/11/14/gpg-key-migration.html

## What approach did you choose and why?
Use both keys, as described in the installation instructions [here](https://docs.hhvm.com/hhvm/installation/linux#ubuntu-16.10-yakkety)

## How can you make sure the change works as expected?
Triggered a garnet build to check if it passes: https://travis-ci.org/travis-infrastructure/packer-build/builds/303523924
