### PR TITLE
Add dbus-x11 as a dependency

### DIFF
--- a/cookbooks/travis_build_environment/recipes/xserver.rb
+++ b/cookbooks/travis_build_environment/recipes/xserver.rb
@@ -24,6 +24,7 @@ package %w[
   x11-xserver-utils
   xserver-xorg-core
   xvfb
+  dbus-x11
 ]
 
 cookbook_file '/etc/init.d/xvfb' do


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
https://github.com/travis-ci/travis-cookbooks/issues/911

## What approach did you choose and why?
Add dbus-x11 as part of the xserver packages

## How can you make sure the change works as expected?
Successful image build: https://travis-ci.org/travis-infrastructure/packer-build/builds/305167237
Checked to see warning was gone in a build VM.
