### PR TITLE
Remove old HHVM GPG key

### DIFF
--- a/cookbooks/travis_build_environment/recipes/hhvm.rb
+++ b/cookbooks/travis_build_environment/recipes/hhvm.rb
@@ -1,9 +1,9 @@
 if node['kernel']['machine'] == 'ppc64le'
   hhvm_uri = 'http://ppa.launchpad.net/ibmpackages/hhvm/ubuntu'
-  key = "E7D1FA0C"
+  key = 'E7D1FA0C'
 else
   hhvm_uri = 'https://dl.hhvm.com/ubuntu'
-  key = %w[0x5a16e7281be7a449 0xB4112585D386EB94]
+  key = '0xB4112585D386EB94'
 end
 
 apt_repository 'hhvm-repository' do


### PR DESCRIPTION
HHVM finished rotating their GPG keys and their install instructions currently include the new key only: https://docs.hhvm.com/hhvm/installation/linux#ubuntu.
Since the old key is no longer useful (and can cause the builds to break, we should remove it)

Test image build: https://travis-ci.org/travis-infrastructure/packer-build/builds/309939102