### PR TITLE
Consolidate postgresql version listing methods

### DIFF
--- a/cookbooks/travis_postgresql/libraries/travis_postgresql_methods.rb
+++ b/cookbooks/travis_postgresql/libraries/travis_postgresql_methods.rb
@@ -1,5 +1,5 @@
 module TravisPostgresqlMethods
-  def pg_versions
+  def pg_versions(node)
     values = [node['travis_postgresql']['default_version']]
     Array(node['travis_postgresql']['alternate_versions']).each do |pg_version|
       values << pg_version

--- a/cookbooks/travis_postgresql/libraries/travis_postgresql_methods.rb
+++ b/cookbooks/travis_postgresql/libraries/travis_postgresql_methods.rb
@@ -1,0 +1,11 @@
+module TravisPostgresqlMethods
+  def pg_versions
+    values = [node['travis_postgresql']['default_version']]
+    Array(node['travis_postgresql']['alternate_versions']).each do |pg_version|
+      values << pg_version
+    end
+    values
+  end
+
+  module_function :pg_versions
+end

--- a/cookbooks/travis_postgresql/recipes/all_packages.rb
+++ b/cookbooks/travis_postgresql/recipes/all_packages.rb
@@ -3,9 +3,13 @@ include_recipe 'travis_postgresql::pgdg'
 
 include_recipe 'travis_postgresql::client'
 
-TravisPostgresqlMethods.pg_versions.each do |pg_version|
-  package "postgresql-#{pg_version}"
-  package "postgresql-contrib-#{pg_version}" if node['travis_postgresql']['contrib_modules']
-end
+package(
+  TravisPostgresqlMethods.pg_versions(node).map do |v|
+    %W[
+      postgresql-#{v}
+      #{node['travis_postgresql']['contrib_modules'] ? "postgresql-contrib-#{v}" : ''}
+    ]
+  end.flatten
+)
 
 include_recipe 'travis_postgresql::postgis' if node['travis_postgresql']['postgis_version']

--- a/cookbooks/travis_postgresql/recipes/all_packages.rb
+++ b/cookbooks/travis_postgresql/recipes/all_packages.rb
@@ -3,11 +3,7 @@ include_recipe 'travis_postgresql::pgdg'
 
 include_recipe 'travis_postgresql::client'
 
-Array(
-  [
-    node['travis_postgresql']['default_version']
-  ] + node['travis_postgresql']['alternate_versions']
-).each do |pg_version|
+TravisPostgresqlMethods.pg_versions.each do |pg_version|
   package "postgresql-#{pg_version}"
   package "postgresql-contrib-#{pg_version}" if node['travis_postgresql']['contrib_modules']
 end

--- a/cookbooks/travis_postgresql/recipes/ci_server.rb
+++ b/cookbooks/travis_postgresql/recipes/ci_server.rb
@@ -46,11 +46,7 @@ execute 'systemctl daemon-reload' do
   only_if { node['lsb']['codename'] == 'xenial' }
 end
 
-Array(
-  [
-    node['travis_postgresql']['default_version']
-  ] + node['travis_postgresql']['alternate_versions']
-).each do |pg_version|
+TravisPostgresqlMethods.pg_versions.each do |pg_version|
   template "/etc/postgresql/#{pg_version}/main/postgresql.conf" do
     source "#{pg_version}/postgresql.conf.erb"
     owner 'postgres'

--- a/cookbooks/travis_postgresql/recipes/ci_server.rb
+++ b/cookbooks/travis_postgresql/recipes/ci_server.rb
@@ -46,7 +46,7 @@ execute 'systemctl daemon-reload' do
   only_if { node['lsb']['codename'] == 'xenial' }
 end
 
-TravisPostgresqlMethods.pg_versions.each do |pg_version|
+TravisPostgresqlMethods.pg_versions(node).each do |pg_version|
   template "/etc/postgresql/#{pg_version}/main/postgresql.conf" do
     source "#{pg_version}/postgresql.conf.erb"
     owner 'postgres'

--- a/cookbooks/travis_postgresql/recipes/postgis.rb
+++ b/cookbooks/travis_postgresql/recipes/postgis.rb
@@ -1,10 +1,7 @@
 ppv = node['travis_postgresql']['postgis_version']
 
 package(
-  (
-    [node['travis_postgresql']['default_version']] +
-    node['travis_postgresql']['alternate_versions']
-  ).map do |v|
+  TravisPostgresqlMethods.pg_versions.map do |v|
     %W[
       postgresql-#{v}-postgis-#{ppv}
       postgresql-#{v}-postgis-#{ppv}-scripts

--- a/cookbooks/travis_postgresql/recipes/postgis.rb
+++ b/cookbooks/travis_postgresql/recipes/postgis.rb
@@ -1,7 +1,7 @@
 ppv = node['travis_postgresql']['postgis_version']
 
 package(
-  TravisPostgresqlMethods.pg_versions.map do |v|
+  TravisPostgresqlMethods.pg_versions(node).map do |v|
     %W[
       postgresql-#{v}-postgis-#{ppv}
       postgresql-#{v}-postgis-#{ppv}-scripts


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Xenial stacks that install multiple PostgreSQL versions are currently failing due to the `node['travis_postgresql']['alternate_versions']` value behavior changing with a recent Chef version upgrade.

## What approach did you choose and why?

Build the PostgreSQL versions array in a different way, and consolidate to a single implementation for use throughout the `travis_postgresql` recipes.

## How can you make sure the change works as expected?

- [x] downstream ci-sardonyx works
- [x] downstream ci-opal works

## Would you like any additional feedback?
