### PR TITLE
Source jdk_switcher via ~travis/.bash_profile.d

### DIFF
--- a/cookbooks/travis_java/recipes/default.rb
+++ b/cookbooks/travis_java/recipes/default.rb
@@ -13,9 +13,13 @@ unless default_java_version.to_s.empty?
 end
 
 include_recipe 'travis_java::jdk_switcher'
+include_recipe 'travis_build_environment::bash_profile_d'
 
-template '/etc/profile.d/travis-java.sh' do
-  source 'travis-java.sh.erb'
+template ::File.join(
+  node['travis_build_environment']['home'],
+  '.bash_profile.d/travis-java.bash'
+) do
+  source 'travis-java.bash.erb'
   owner node['travis_build_environment']['user']
   group node['travis_build_environment']['group']
   mode 0o755

--- a/cookbooks/travis_java/templates/default/travis-java.bash.erb
+++ b/cookbooks/travis_java/templates/default/travis-java.bash.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 <% unless @jdk_switcher_default.nil? || @jdk_switcher_default.empty? -%>
 export JDK_SWITCHER_DEFAULT="<%= @jdk_switcher_default -%>"
 <% end -%>
@@ -6,7 +6,7 @@ export JDK_SWITCHER_DEFAULT="<%= @jdk_switcher_default -%>"
 export JAVA_HOME="<%= @jvm_base_dir -%>/<%= @jvm_name -%>"
 export _JAVA_OPTIONS="-Xmx2048m -Xms512m"
 <% end -%>
-if [ -f "<%= @jdk_switcher_path -%>" ]; then
-  . "<%= @jdk_switcher_path -%>"
+if [[ -f "<%= @jdk_switcher_path -%>" ]]; then
+  source "<%= @jdk_switcher_path -%>"
 fi
 export MALLOC_ARENA_MAX=2


### PR DESCRIPTION
instead of /etc/profile.d, as the latter is loaded by all users and the
contents are supposed to be sh-compatible, whereas jdk_switcher has
bash-specific stuff.

Closes #964