### PR TITLE
Disable APT Periodic updates

### DIFF
--- a/cookbooks/travis_build_environment/files/default/10periodic
+++ b/cookbooks/travis_build_environment/files/default/10periodic
@@ -1,2 +1,3 @@
 # Managed by Chef! <3 <3 <3
+APT::Periodic::Enable "0";
 APT::Periodic::Update-Package-Lists "0";


### PR DESCRIPTION
so that apt-daily.service and apt-daily-upgrade.service don't try to
start on every boot and conflict with other operations that need to dpkg
locky lock.