### PR TITLE
Set docker version to 18.03.1

### DIFF
--- a/cookbooks/travis_docker/attributes/default.rb
+++ b/cookbooks/travis_docker/attributes/default.rb
@@ -2,16 +2,16 @@
 # Trusty and Xenial. When updating check the version exists in both of:
 # https://download.docker.com/linux/ubuntu/dists/trusty/stable/binary-amd64/Packages
 # https://download.docker.com/linux/ubuntu/dists/xenial/stable/binary-amd64/Packages
-default['travis_docker']['version'] = '17.12.1~ce-0~ubuntu'
+default['travis_docker']['version'] = '18.03.1~ce-0~ubuntu'
 default['travis_docker']['users'] = %w[travis]
 default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.17.1/docker-compose-Linux-x86_64'
 default['travis_docker']['compose']['sha256sum'] = 'db0a7b79d195dc021461d5628a8d53eeb2e556d2548b764770fccabb0a319dd8'
 default['travis_docker']['update_grub'] = true
-default['travis_docker']['binary']['url'] = "https://download.docker.com/linux/static/stable/#{node['kernel']['machine']}/docker-17.12.1-ce.tgz"
-default['travis_docker']['binary']['version'] = '17.12.1-ce'
-default['travis_docker']['binary']['checksum'] = 'f1722346f98463e44018dc9f1ce5c56c4b203d4237ecc8f4b4fbc1eac1693f18'
+default['travis_docker']['binary']['version'] = '18.03.1-ce'
+default['travis_docker']['binary']['checksum'] = '0e245c42de8a21799ab11179a4fce43b494ce173a8a2d6567ea6825d6c5265aa'
+default['travis_docker']['binary']['url'] = "https://download.docker.com/linux/static/stable/#{node['kernel']['machine']}/docker-#{node['travis_docker']['binary']['version']}.tgz"
 if node['kernel']['machine'] == 'ppc64le'
-  default['travis_docker']['binary']['checksum'] = 'f00d4cefd392893241e5ae3be292ade0e9076cbba6fde56e731ae5002558b82a'
+  default['travis_docker']['binary']['checksum'] = '7633a67fa2be7d37700c6809968cd3692a8e0924cf05b4dd9f51c56bdbbdab10'
 end
 default['travis_docker']['binary']['binaries'] = %w[
   docker


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
And correct the checksums, and variabelize the url with the version.

## What approach did you choose and why?
Ensure the hash matches the target.

## How can you make sure the change works as expected?
https://travis-ci.org/travis-infrastructure/packer-build/jobs/380192830#L1759

## Would you like any additional feedback?
Should the version definition + file hash move over to [paker-tyemplates](https://github.com/travis-ci/packer-templates/blob/master/cookbooks/travis_ci_stevonnie/attributes/default.rb)?