### PR TITLE
Update ShellCheck from v0.4.7 to v0.5.0

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -262,9 +262,9 @@ mercurial_ppc_version = '4.2.2'
 default['travis_build_environment']['mercurial_ppc_version'] = mercurial_ppc_version
 default['travis_build_environment']['mercurial_url'] = "https://www.mercurial-scm.org/release/mercurial-#{mercurial_ppc_version}.tar.gz"
 
-default['travis_build_environment']['shellcheck_url'] = 'https://storage.googleapis.com/shellcheck/shellcheck-v0.4.7.linux.x86_64.tar.xz'
-default['travis_build_environment']['shellcheck_version'] = '0.4.7'
-default['travis_build_environment']['shellcheck_checksum'] = 'deeea92a4d3a9c5b16ba15210d9c1ab84a2e12e29bf856427700afd896bbdc93'
+default['travis_build_environment']['shellcheck_url'] = 'https://storage.googleapis.com/shellcheck/shellcheck-v0.5.0.linux.x86_64.tar.xz'
+default['travis_build_environment']['shellcheck_version'] = '0.5.0'
+default['travis_build_environment']['shellcheck_checksum'] = '7d4c073a0342cf39bdb99c32b4749f1c022cf2cffdfb080c12c106aa9d341708'
 default['travis_build_environment']['shellcheck_binaries'] = %w[shellcheck]
 
 default['travis_build_environment']['shfmt_url'] = 'https://github.com/mvdan/sh/releases/download/v2.0.0/shfmt_v2.0.0_linux_amd64'


### PR DESCRIPTION
ShellCheck v0.5.0 just released
 - https://github.com/koalaman/shellcheck/releases/tag/v0.5.0