### PR TITLE
Update shfmt from v2.0.0 to v2.4.0

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -267,8 +267,8 @@ default['travis_build_environment']['shellcheck_version'] = '0.4.7'
 default['travis_build_environment']['shellcheck_checksum'] = 'deeea92a4d3a9c5b16ba15210d9c1ab84a2e12e29bf856427700afd896bbdc93'
 default['travis_build_environment']['shellcheck_binaries'] = %w[shellcheck]
 
-default['travis_build_environment']['shfmt_url'] = 'https://github.com/mvdan/sh/releases/download/v2.0.0/shfmt_v2.0.0_linux_amd64'
-default['travis_build_environment']['shfmt_checksum'] = 'f21ec3c37b9ece776a737629650adcb79f7b529026b967432a8a2c2b40dcabe0'
+default['travis_build_environment']['shfmt_url'] = 'https://github.com/mvdan/sh/releases/download/v2.4.0/shfmt_v2.4.0_linux_amd64'
+default['travis_build_environment']['shfmt_checksum'] = 'abc78150f5d3afa10afe0dd8fef2c431729e14fdc77fde2bab6a3d869f551599'
 
 default['travis_build_environment']['yarn_url'] = 'https://yarnpkg.com/latest.tar.gz'
 default['travis_build_environment']['yarn_version'] = 'latest'


### PR DESCRIPTION
shfmt v2.4.0 has been released for a while
- https://github.com/mvdan/sh/releases/tag/v2.4.0