### PR TITLE
Add xdpyinfo to xserver recipe

### DIFF
--- a/cookbooks/travis_build_environment/recipes/xserver.rb
+++ b/cookbooks/travis_build_environment/recipes/xserver.rb
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 package %w[
+  x11-utils
   x11-xserver-utils
   xserver-xorg-core
   xvfb


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Missing command xdpy-info causing the tests to fail.

## What approach did you choose and why?
Add x11utils to the required packages of the xserver cookbook.

## How can you make sure the change works as expected?
Test succeeds here:
https://travis-ci.org/travis-infrastructure/packer-build/jobs/386800885#L3850

## Would you like any additional feedback?
