### PR TITLE
Excluding grub command line option for power

### DIFF
--- a/cookbooks/travis_docker/recipes/default.rb
+++ b/cookbooks/travis_docker/recipes/default.rb
@@ -45,6 +45,7 @@ cookbook_file '/etc/default/grub.d/99-travis-settings.cfg' do
   owner 'root'
   group 'root'
   mode 0o640
+  not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
 execute 'update-grub' do


### PR DESCRIPTION
This change was required as we noticed that the openstack based base images were failing to boot up successful vm instances - in spite of it showing vm instance as "running" state on the openstack dashboard .

The instance was repeatedly rebooting and I couldn't find any errors. So I got on the console and just adjusted the
kernel boot line taking out "console=ttyS0" and "quiet"  and for some reason doing that caused it to boot up normally. Narrowed down that this was happening due to this command line option here ..

$ git  grep "GRUB_CMD"
cookbooks/travis_docker/files/default/etc/default/grub.d/99-travis-settings.cfg:GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1 apparmor=0 console=ttyS0"

So removing this option will help vm instances boot up successfully on power

## What is the problem that this PR is trying to fix?
- Issue faced with stevonnie/sardonyx stack based images ( for ppc64le) at osu/osl . The power vm instances created using these stacks were unable to boot up successfully and were rebooting always

## What approach did you choose and why?
- For whatever reason, the instance was repeatedly rebooting and I couldn't find any errors. So I got on the console and just adjusted the kernel boot line taking out "console=ttyS0" and "quiet"
 and for some reason doing that caused it to boot up normally.

## How can you make sure the change works as expected?
- Tried it at osu/osl.

## Would you like any additional feedback?
- Yes