### PR TITLE
update rebar3 to 3.6.2

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -104,8 +104,9 @@ end
 
 default['travis_build_environment']['rebar_url'] = \
   'https://github.com/rebar/rebar/wiki/rebar'
-default['travis_build_environment']['rebar3_url'] = \
-  'https://s3.amazonaws.com/rebar3/rebar3'
+default['travis_build_environment']['rebar3_url'] = 'https://s3.amazonaws.com/rebar3/rebar3'
+default['travis_build_environment']['rebar3_version'] = '3.6.1'
+default['travis_build_environment']['rebar3_checksum'] = 'a196c84a860bea5d5e68d0146cb04aa0f55332c640f3895a5400a05d684915a1'
 default['travis_build_environment']['kerl_path'] = '/usr/local/bin/kerl'
 default['travis_build_environment']['kerl_base_dir'] = \
   "#{node['travis_build_environment']['home']}/.kerl"

--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -105,8 +105,8 @@ end
 default['travis_build_environment']['rebar_url'] = \
   'https://github.com/rebar/rebar/wiki/rebar'
 default['travis_build_environment']['rebar3_url'] = 'https://s3.amazonaws.com/rebar3/rebar3'
-default['travis_build_environment']['rebar3_version'] = '3.6.1'
-default['travis_build_environment']['rebar3_checksum'] = 'a196c84a860bea5d5e68d0146cb04aa0f55332c640f3895a5400a05d684915a1'
+default['travis_build_environment']['rebar3_version'] = '3.6.2'
+default['travis_build_environment']['rebar3_checksum'] = '2a107ee8f88de431d89f7a3bdccaf4b7bbba268cd02ab2e7ebf1e7976798b9bf'
 default['travis_build_environment']['kerl_path'] = '/usr/local/bin/kerl'
 default['travis_build_environment']['kerl_base_dir'] = \
   "#{node['travis_build_environment']['home']}/.kerl"


### PR DESCRIPTION
See the fishcakez/acceptor_pool#9
The rebar3 version now is 3.6.1, but the travis -ci is still 3.4.7, it needs to be udpated.