### PR TITLE
Fix sonatype-apache maven repository

### DIFF
--- a/cookbooks/travis_build_environment/files/default/ci_user/maven_user_settings.xml
+++ b/cookbooks/travis_build_environment/files/default/ci_user/maven_user_settings.xml
@@ -64,7 +64,7 @@
             <updatePolicy>never</updatePolicy>
             <checksumPolicy>fail</checksumPolicy>
           </snapshots>
-          <url>https://repository.apache.org/releases/</url>
+          <url>https://repository.apache.org/content/repositories/releases/</url>
         </repository>
 
         <repository>


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
When using maven, the build hangs, because it tries to download dependencies from https://repository.apache.org/releases/ which does not exists.
for e.g. here: https://travis-ci.org/jkasztur/windup-plugin/builds/425401550
## What approach did you choose and why?
I fixed the repository url to an existing one
## How can you make sure the change works as expected?
I modified my travis.ci and tested with:
```
before_install:
 - sed -i.bak -e 's|https://repository.apache.org/releases/|https://repository.apache.org/content/repositories/releases/|g' ~/.m2/settings.xml
```
build: https://travis-ci.org/jkasztur/windup-plugin/builds/426312876
## Would you like any additional feedback?
Should the repository be changed also somewhere else?