### PR TITLE
Bump versions, make redis installable again

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -188,7 +188,7 @@ default['travis_build_environment']['elasticsearch']['jvm_heap'] = '128m'
 default['travis_build_environment']['redis']['service_enabled'] = false
 default['travis_build_environment']['redis']['keep_repo'] = false
 
-default['travis_build_environment']['firefox_version'] = '56.0.2'
+default['travis_build_environment']['firefox_version'] = '63.0.1'
 default['travis_build_environment']['firefox_download_url'] = ::File.join(
   'https://releases.mozilla.org/pub/firefox/releases',
   node['travis_build_environment']['firefox_version'],

--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -220,16 +220,14 @@ default['travis_build_environment']['gimme']['install_user'] = 'travis'
 default['travis_build_environment']['gimme']['install_user_home'] = '/home/travis'
 default['travis_build_environment']['gimme']['debug'] = false
 
-default['travis_build_environment']['haskell_ghc_versions'] = %w[
-  7.10.3
-  8.0.2
+default['travis_build_environment']['haskell']['ghc_versions'] = %w[
+  8.6.1
 ]
-default['travis_build_environment']['haskell_cabal_versions'] = %w[
-  1.22
-  1.24
+default['travis_build_environment']['haskell']['cabal_versions'] = %w[
+  2.2
+  2.4
 ]
-default['travis_build_environment']['haskell_default_ghc'] = '7.10.3'
-default['travis_build_environment']['haskell_default_cabal'] = '1.22'
+default['travis_build_environment']['haskell']['keep_repo'] = false
 
 gradle_version = '4.10.2'
 default['travis_build_environment']['gradle_version'] = gradle_version

--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -196,23 +196,23 @@ default['travis_build_environment']['firefox_download_url'] = ::File.join(
   "firefox-#{node['travis_build_environment']['firefox_version']}.tar.bz2"
 )
 
-default['travis_build_environment']['clang']['version'] = '5.0.0'
+default['travis_build_environment']['clang']['version'] = '7.0.0'
 default['travis_build_environment']['clang']['download_url'] = ::File.join(
   'http://releases.llvm.org',
   node['travis_build_environment']['clang']['version'],
-  "clang+llvm-#{node['travis_build_environment']['clang']['version']}-linux-x86_64-ubuntu14.04.tar.xz"
+  "clang+llvm-#{node['travis_build_environment']['clang']['version']}-x86_64-linux-gnu-ubuntu-16.04.tar.xz"
 )
 default['travis_build_environment']['clang']['extension'] = 'tar.xz'
-default['travis_build_environment']['clang']['checksum'] = '58c1171f326108cfb7641441c5ede7846d58823bce3206c86a84c7ef7748860d'
+default['travis_build_environment']['clang']['checksum'] = '69b85c833cd28ea04ce34002464f10a6ad9656dd2bba0f7133536a9927c660d2'
 
-default['travis_build_environment']['cmake']['version'] = '3.9.2'
+default['travis_build_environment']['cmake']['version'] = '3.12.4'
 default['travis_build_environment']['cmake']['download_url'] = ::File.join(
   'https://cmake.org/files',
   "v#{node['travis_build_environment']['cmake']['version'].split('.')[0, 2].join('.')}",
   "cmake-#{node['travis_build_environment']['cmake']['version']}-Linux-x86_64.tar.gz"
 )
 default['travis_build_environment']['cmake']['extension'] = 'tar.gz'
-default['travis_build_environment']['cmake']['checksum'] = 'f4e1e848e21c3fba134fbddd793860ba9a17c35d0aeaa3bd83149a6ec1bf9fbb'
+default['travis_build_environment']['cmake']['checksum'] = '486edd6710b5250946b4b199406ccbf8f567ef0e23cfe38f7938b8c78a2ffa5f'
 
 default['travis_build_environment']['gimme']['default_version'] = '1.11.1'
 default['travis_build_environment']['gimme']['versions'] = %w[1.11.1]

--- a/cookbooks/travis_build_environment/recipes/redis.rb
+++ b/cookbooks/travis_build_environment/recipes/redis.rb
@@ -4,15 +4,19 @@ apt_repository 'ppa:redis-server' do
   uri 'ppa:chris-lea/redis-server'
 end
 
-package 'redis-server' do
+package %w[redis-server redis-tools] do
   action :install
+end
+
+execute 'redis do not listen to ipv6' do
+  command "sed -ie 's/^bind.*/bind 127.0.0.1/' /etc/redis/redis.conf"
 end
 
 service 'redis-server' do
   if node['travis_build_environment']['redis']['service_enabled']
-    action %i[enable start]
+    action %i[enable restart]
   else
-    action %i[disable start]
+    action %i[disable restart]
   end
 end
 

--- a/cookbooks/travis_build_environment/recipes/security.rb
+++ b/cookbooks/travis_build_environment/recipes/security.rb
@@ -22,12 +22,31 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+%w[user system].each do |target|
+  dir = "/etc/systemd/#{target}.conf.d"
+
+  directory dir do
+    owner 'root'
+    group 'root'
+    mode 0o755
+  end
+
+  template "#{dir}/limits.conf" do
+    source 'etc-systemd-conf-d-limits.conf.erb'
+    owner 'root'
+    group 'root'
+    mode 0o644
+  end
+end
+
 template '/etc/security/limits.conf' do
   source 'etc/security/limits.conf.erb'
   owner 'root'
   group 'root'
   mode 0o644
 end
+
+execute 'systemctl daemon-reexec'
 
 cookbook_file '/etc/sudoers.d/env_keep' do
   source 'etc/sudoers/env_keep'

--- a/cookbooks/travis_build_environment/templates/default/etc-systemd-conf-d-limits.conf.erb
+++ b/cookbooks/travis_build_environment/templates/default/etc-systemd-conf-d-limits.conf.erb
@@ -1,0 +1,2 @@
+[Manager]
+DefaultLimitNOFILE=131072

--- a/cookbooks/travis_docker/attributes/default.rb
+++ b/cookbooks/travis_docker/attributes/default.rb
@@ -4,18 +4,18 @@
 # Trusty and Xenial. When updating check the version exists in both of:
 # https://download.docker.com/linux/ubuntu/dists/trusty/stable/binary-amd64/Packages
 # https://download.docker.com/linux/ubuntu/dists/xenial/stable/binary-amd64/Packages
-default['travis_docker']['version'] = '18.03.1~ce-0~ubuntu'
+default['travis_docker']['version'] = '18.06.0~ce~3-0~ubuntu'
 default['travis_docker']['users'] = %w[travis]
-default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.17.1/docker-compose-Linux-x86_64'
-default['travis_docker']['compose']['sha256sum'] = 'db0a7b79d195dc021461d5628a8d53eeb2e556d2548b764770fccabb0a319dd8'
+default['travis_docker']['compose']['url'] = 'https://github.com/docker/compose/releases/download/1.23.1/docker-compose-Linux-x86_64'
+default['travis_docker']['compose']['sha256sum'] = 'c176543737b8aea762022245f0f4d58781d3cb1b072bc14f3f8e5bb96f90f1a2'
 default['travis_docker']['update_grub'] = true
-default['travis_docker']['binary']['version'] = '18.03.1-ce'
-default['travis_docker']['binary']['checksum'] = '0e245c42de8a21799ab11179a4fce43b494ce173a8a2d6567ea6825d6c5265aa'
+default['travis_docker']['binary']['version'] = '18.06.1-ce'
+default['travis_docker']['binary']['checksum'] = '83be159cf0657df9e1a1a4a127d181725a982714a983b2bdcc0621244df93687'
 machine = node['kernel']['machine']
 version = node['travis_docker']['binary']['version']
 default['travis_docker']['binary']['url'] = "https://download.docker.com/linux/static/stable/#{machine}/docker-#{version}.tgz"
 if node['kernel']['machine'] == 'ppc64le'
-  default['travis_docker']['binary']['checksum'] = '7633a67fa2be7d37700c6809968cd3692a8e0924cf05b4dd9f51c56bdbbdab10'
+  default['travis_docker']['binary']['checksum'] = '479083ac0b2bae839782ea53870809b8590f440db5f0bdf1294eac95e1a2ec3b'
 end
 default['travis_docker']['binary']['binaries'] = %w[
   docker

--- a/cookbooks/travis_docker/recipes/package.rb
+++ b/cookbooks/travis_docker/recipes/package.rb
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-arch = node['kernel']['machine'] =~ /x86_64/ ? 'amd64' : 'ppc64el'
+arch = node['kernel']['machine'] =~ /x86_64/ ? 'amd64' : 'ppc64le'
 apt_repository 'docker' do
   uri 'https://download.docker.com/linux/ubuntu'
   arch arch


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
bump versions of:
- firefox
- clang
- cmake
- docker
- docker-compose
- redis new version from ppa

## What approach did you choose and why?

## How can you make sure the change works as expected?

## Would you like any additional feedback?
