### PR TITLE
JAVA_OPTIONS && hhvm removal

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -136,7 +136,7 @@ default['travis_build_environment']['ramfs_size'] = '768m'
 default['travis_build_environment']['bats_git_repository'] = \
   'https://github.com/sstephenson/bats.git'
 
-default['travis_build_environment']['hhvm_enabled'] = true
+default['travis_build_environment']['hhvm_enabled'] = false
 default['travis_build_environment']['hhvm_package_name'] = 'hhvm'
 default['travis_build_environment']['php_packages'] = %w[
   autoconf

--- a/cookbooks/travis_jdk/recipes/default.rb
+++ b/cookbooks/travis_jdk/recipes/default.rb
@@ -91,6 +91,7 @@ template ::File.join(
   mode 0o644
   variables(
     jdk: node['travis_jdk']['default'],
-    path: node['travis_jdk']['destination_path']
+    path: node['travis_jdk']['destination_path'],
+    docker: node['virtualization']['system'] == 'docker'
   )
 end

--- a/cookbooks/travis_jdk/templates/travis_jdk.bash.erb
+++ b/cookbooks/travis_jdk/templates/travis_jdk.bash.erb
@@ -3,6 +3,8 @@ if [[ -d <%= @path =%>/<%= @jdk =%> ]]; then
   export JAVA_HOME=<%= @path =%>/<%= @jdk %>
   export PATH="$JAVA_HOME/bin:$PATH"
 fi
+<% if @docker %>
 export _JAVA_OPTIONS='-Xmx2048m -Xms512m'
 export MALLOC_ARENA_MAX=2
+<% end %>
 <% end %>


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
* Set the environment variable `_JAVA_OPTIONS` conditionally, when running on a container builder.

* Remove hhvm from the default install, as the apt repository has had some issues.

## What approach did you choose and why?

## How can you make sure the change works as expected?

## Would you like any additional feedback?
