### PR TITLE
Upgrading packer version for ppc64le

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -124,11 +124,11 @@ default['travis_build_environment']['packer_checksum'] = \
   '5e51808299135fee7a2e664b09f401b5712b5ef18bd4bad5bc50f4dcd8b149a1'
 default['travis_build_environment']['packer_version'] = '1.3.2'
 if node['kernel']['machine'] == 'ppc64le'
-  default['travis_build_environment']['packer_version'] = '1.1.3'
+  default['travis_build_environment']['packer_version'] = '1.3.2'
   default['travis_build_environment']['packer_url'] = \
-    'https://releases.hashicorp.com/packer/1.1.3/packer_1.1.3_linux_ppc64le.zip'
+    'https://releases.hashicorp.com/packer/1.3.2/packer_1.3.2_linux_ppc64le.zip'
   default['travis_build_environment']['packer_checksum'] = \
-    '25ecb9b4592924c9d04ef2cb3796690827e559e24789efacefc58f795676d329'
+    'f3a2aec3a0a54d5d9cc6047f52acb73202b30efea770d4627459ca5608e58ac1'
 end
 default['travis_build_environment']['packer_binaries'] = %w[packer]
 default['travis_build_environment']['ramfs_dir'] = '/var/ramfs'


### PR DESCRIPTION
- Upgraded packer version from 1.1.3 to 1.3.2
- latest packer version for ppc64le is present here - https://releases.hashicorp.com/packer/1.3.2/

## What is the problem that this PR is trying to fix?
Was getting below error whilst trying to create travis base images for docker backend using packer command on "packer-templates" repository.
```
$ nohup packer build -on-error=abort -only= docker <(bin/yml2json < ci-stevonnie.yml) > stevonnie_ docker &

==> docker: Provisioning with shell script: packer-scripts/test-system-info-output
    docker: program packer version has 4 lines output
    docker: sudo: unable to resolve host 5bb137e28df4
    docker:     Packer v1.1.3
    docker:
    docker:     Your version of Packer is out of date! The latest version
    docker:     is 1.3.2. You can update by downloading from www.packer.io/downloads.html
==> docker: Script exited with non-zero exit status: 1
==> docker: Step "StepProvision" failed, aborting... 
```

## What approach did you choose and why?
Post upgrading in a forked branch of travis-cookbooks and then using the same in packer-templates packer command , the above error wasn't seen
## How can you make sure the change works as expected?
With the above changes above error wasn't encountered during the image creation process for "stevonnie/docker".
## Would you like any additional feedback?
None