### PR TITLE
Bump packer version

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -118,15 +118,11 @@ default['travis_build_environment']['elixir_versions'] = %w[
 default['travis_build_environment']['required_otp_release_for']['1.7.4'] = '21.1'
 default['travis_build_environment']['default_elixir_version'] = '1.7.4'
 default['travis_build_environment']['mysql']['socket'] = '/var/run/mysqld/mysqld.sock'
-default['travis_build_environment']['packer_url'] = \
-  'https://releases.hashicorp.com/packer/1.3.2/packer_1.3.2_linux_amd64.zip'
+default['travis_build_environment']['packer_version'] = '1.3.3'
 default['travis_build_environment']['packer_checksum'] = \
-  '5e51808299135fee7a2e664b09f401b5712b5ef18bd4bad5bc50f4dcd8b149a1'
-default['travis_build_environment']['packer_version'] = '1.3.2'
+  'efa311336db17c0709d5069509c34c35f0d59c63dfb05f61d4572c5a26b563ea'
 if node['kernel']['machine'] == 'ppc64le'
-  default['travis_build_environment']['packer_version'] = '1.3.2'
-  default['travis_build_environment']['packer_url'] = \
-    'https://releases.hashicorp.com/packer/1.3.2/packer_1.3.2_linux_ppc64le.zip'
+  default['travis_build_environment']['packer_version'] = '1.3.3'
   default['travis_build_environment']['packer_checksum'] = \
     'f3a2aec3a0a54d5d9cc6047f52acb73202b30efea770d4627459ca5608e58ac1'
 end

--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -118,14 +118,12 @@ default['travis_build_environment']['elixir_versions'] = %w[
 default['travis_build_environment']['required_otp_release_for']['1.7.4'] = '21.1'
 default['travis_build_environment']['default_elixir_version'] = '1.7.4'
 default['travis_build_environment']['mysql']['socket'] = '/var/run/mysqld/mysqld.sock'
-default['travis_build_environment']['packer_version'] = '1.3.3'
-default['travis_build_environment']['packer_checksum'] = \
+default['travis_build_environment']['packer']['amd64']['version'] = '1.3.3'
+default['travis_build_environment']['packer']['amd64']['checksum'] = \
   'efa311336db17c0709d5069509c34c35f0d59c63dfb05f61d4572c5a26b563ea'
-if node['kernel']['machine'] == 'ppc64le'
-  default['travis_build_environment']['packer_version'] = '1.3.3'
-  default['travis_build_environment']['packer_checksum'] = \
-    'f3a2aec3a0a54d5d9cc6047f52acb73202b30efea770d4627459ca5608e58ac1'
-end
+default['travis_build_environment']['packer']['ppc64le']['version'] = '1.3.2'
+default['travis_build_environment']['packer']['ppc64le']['checksum'] = \
+  'f3a2aec3a0a54d5d9cc6047f52acb73202b30efea770d4627459ca5608e58ac1'
 default['travis_build_environment']['packer_binaries'] = %w[packer]
 default['travis_build_environment']['ramfs_dir'] = '/var/ramfs'
 default['travis_build_environment']['ramfs_size'] = '768m'

--- a/cookbooks/travis_build_environment/recipes/packer.rb
+++ b/cookbooks/travis_build_environment/recipes/packer.rb
@@ -22,15 +22,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-packer_version = node['travis_build_environment']['packer_version']
-arch = 'amd64'
-arch = 'ppc64le' if node['kernel']['machine'] == 'ppc64le'
-packer_url = "https://releases.hashicorp.com/packer/#{packer_version}/packer_#{packer_version}_linux_#{arch}.zip"
-
 ark 'packer' do
-  version packer_version
-  checksum node['travis_build_environment']['packer_checksum']
-  url packer_url
+  arch = node['kernel']['machine'].gsub(/x86_64/, 'amd64')
+  version node['travis_build_environment']['packer'][arch]['version']
+  checksum node['travis_build_environment']['packer'][arch]['checksum']
+  url "https://releases.hashicorp.com/packer/#{version}/packer_#{version}_linux_#{arch}.zip"
   strip_components 0
   has_binaries node['travis_build_environment']['packer_binaries']
 end

--- a/cookbooks/travis_build_environment/recipes/packer.rb
+++ b/cookbooks/travis_build_environment/recipes/packer.rb
@@ -22,10 +22,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+packer_version = node['travis_build_environment']['packer_version']
+arch = 'amd64'
+arch = 'ppc64le' if node['kernel']['machine'] == 'ppc64le'
+packer_url = "https://releases.hashicorp.com/packer/#{packer_version}/packer_#{packer_version}_linux_#{arch}.zip"
+
 ark 'packer' do
-  url node['travis_build_environment']['packer_url']
-  version node['travis_build_environment']['packer_version']
+  version packer_version
   checksum node['travis_build_environment']['packer_checksum']
+  url packer_url
   strip_components 0
   has_binaries node['travis_build_environment']['packer_binaries']
 end


### PR DESCRIPTION
New packer release is out, let's include it. Also, derive the download url from version and cpu arch.