### PR TITLE
Override GCE default to always enable IPv4 forwarding

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -238,6 +238,7 @@ default['travis_build_environment']['lein_url'] = 'https://raw.githubusercontent
 
 default['travis_build_environment']['sysctl_kernel_shmmax'] = 45_794_432
 default['travis_build_environment']['sysctl_disable_ipv6'] = true
+default['travis_build_environment']['sysctl_enable_ipv4_forwarding'] = true
 
 maven_version = '3.5.4'
 default['travis_build_environment']['maven_version'] = maven_version

--- a/cookbooks/travis_build_environment/recipes/sysctl.rb
+++ b/cookbooks/travis_build_environment/recipes/sysctl.rb
@@ -36,9 +36,7 @@ execute 'update sysctl travis-enable-ipv4-forwarding' do
 end
 
 file '/etc/sysctl.d/99-travis-enable-ipv4-forwarding.conf' do
-  content <<-IPV4_CONFIG.gsub(/^\s+> ?/, '')
-    > net.ipv4.ip_forward = 1
-  IPV4_CONFIG
+  content "net.ipv4.ip_forward = 1\n"
   owner 'root'
   group 'root'
   mode 0o644

--- a/cookbooks/travis_build_environment/recipes/sysctl.rb
+++ b/cookbooks/travis_build_environment/recipes/sysctl.rb
@@ -36,7 +36,6 @@ execute 'update sysctl travis-enable-ipv4-forwarding' do
 end
 
 file '/etc/sysctl.d/99-travis-enable-ipv4-forwarding.conf' do
-  content "net.ipv4.ip_forward = 1"
   content <<-IPV4_CONFIG.gsub(/^\s+> ?/, '')
     > net.ipv4.ip_forward = 1
   IPV4_CONFIG

--- a/cookbooks/travis_build_environment/recipes/sysctl.rb
+++ b/cookbooks/travis_build_environment/recipes/sysctl.rb
@@ -29,3 +29,20 @@ file '/etc/sysctl.d/99-travis-disable-ipv6.conf' do
   only_if { node['travis_build_environment']['sysctl_disable_ipv6'] }
   notifies :run, 'execute[update sysctl travis-disable-ipv6]'
 end
+
+execute 'update sysctl travis-enable-ipv4-forwarding' do
+  command 'sysctl -p /etc/sysctl.d/99-travis-enable-ipv4-forwarding.conf'
+  action :nothing
+end
+
+file '/etc/sysctl.d/99-travis-enable-ipv4-forwarding.conf' do
+  content "net.ipv4.ip_forward = 1"
+  content <<-IPV4_CONFIG.gsub(/^\s+> ?/, '')
+    > net.ipv4.ip_forward = 1
+  IPV4_CONFIG
+  owner 'root'
+  group 'root'
+  mode 0o644
+  only_if { node['travis_build_environment']['sysctl_enable_ipv4_forwarding'] }
+  notifies :run, 'execute[update sysctl travis-enable-ipv4-forwarding]'
+end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

On GCE, the VM images we are using ship with a file at `/etc/sysctl.d/99-gce.conf` which contains:
```
net.ipv4.ip_forward = 0
```

This kernel parameter determines whether packets can be forwarded between network interfaces. It is set to `0` by default. The Docker daemon sets it to `1` when it starts, but GCE VMs have their sysctl settings reset to defaults once per day, which causes any existing Docker containers running within jobs to lose connectivity to the internet (in particular, causing DNS lookups in Docker to fail).

This change addresses https://github.com/travis-ci/travis-ci/issues/9696

## What approach did you choose and why?

This PR results in the addition of `/etc/sysctl.d/99-travis-enable-ipv4-forwarding.conf` on all GCE VMs containing the following line:
```
net.ipv4.ip_forward = 1
```
This should have the effect of enabling IPv4 forwarding for all jobs in a way that won't be overridden when the sysctl settings get a daily default reset by GCE.

## How can you make sure the change works as expected?

A long-running jobs doing continuous DNS lookups in Docker should not start failing around 07:00 UTC daily (like [so](https://travis-ci.org/soulshake/startup-threads-cli/builds/465528751#L2933-L2943)). 

## Would you like any additional feedback?

- Are there any potential negative consequences of enabling IPv4 forwarding on all jobs?
- Instead of enabling IPv4 forwarding on all jobs, would it be better to enable it only on jobs with `services: docker`?
- Is `only_if { node['travis_build_environment']['sysctl_enable_ipv4_forwarding'] }` really necessary?