### PR TITLE
Bump packer version for ppc64le

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -121,9 +121,9 @@ default['travis_build_environment']['mysql']['socket'] = '/var/run/mysqld/mysqld
 default['travis_build_environment']['packer']['amd64']['version'] = '1.3.3'
 default['travis_build_environment']['packer']['amd64']['checksum'] = \
   'efa311336db17c0709d5069509c34c35f0d59c63dfb05f61d4572c5a26b563ea'
-default['travis_build_environment']['packer']['ppc64le']['version'] = '1.3.2'
+default['travis_build_environment']['packer']['ppc64le']['version'] = '1.3.3'
 default['travis_build_environment']['packer']['ppc64le']['checksum'] = \
-  'f3a2aec3a0a54d5d9cc6047f52acb73202b30efea770d4627459ca5608e58ac1'
+  '4b8bc93a2bf406fb035968815c680f171830ff7246de9594c08a15ac0c9a18d8'
 default['travis_build_environment']['packer_binaries'] = %w[packer]
 default['travis_build_environment']['ramfs_dir'] = '/var/ramfs'
 default['travis_build_environment']['ramfs_size'] = '768m'


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Packer binary for power was recently added here - https://releases.hashicorp.com/packer/1.3.3/ after my github issue here - https://github.com/hashicorp/packer/issues/7097. 

## What approach did you choose and why?
Packer moved to latest version 1.3.3 , which had missed adding power binaries.  validated below
```
# wget https://releases.hashicorp.com/packer/1.3.3/packer_1.3.3_linux_ppc64le.zip
# ls -l | grep packer
-rw-r--r--  1 root root 25550872 Dec 11 17:27 packer_1.3.3_linux_ppc64le.zip
# unzip packer_1.3.3_linux_ppc64le.zip
~# ./packer version
Packer v1.3.3
# sha256sum packer_1.3.3_linux_ppc64le.zip
4b8bc93a2bf406fb035968815c680f171830ff7246de9594c08a15ac0c9a18d8
```
## How can you make sure the change works as expected?
As seen above,

## Would you like any additional feedback?
None

@joepvd - please review.