### PR TITLE
Remove google_chrome from features on ppc64le

### DIFF
--- a/cookbooks/travis_build_environment/recipes/google_chrome.rb
+++ b/cookbooks/travis_build_environment/recipes/google_chrome.rb
@@ -8,11 +8,23 @@ apt_repository 'google-chrome' do
   key 'https://dl-ssl.google.com/linux/linux_signing_key.pub'
   retries 2
   retry_delay 30
+  not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
-package 'google-chrome-stable'
+package 'google-chrome-stable' do
+  not_if { node['kernel']['machine'] == 'ppc64le' }
+end
 
 apt_repository 'google-chrome' do
   action :remove
   not_if { node['travis_build_environment']['google_chrome']['keep_repo'] }
+  not_if { node['kernel']['machine'] == 'ppc64le' }
+end
+
+ruby_block 'job_board adjustments google-chrome ppc64le' do
+  only_if { node['kernel']['machine'] == 'ppc64le' }
+  block do
+    features = node['travis_packer_templates']['job_board']['features'] - ['google-chrome']
+    override['travis_packer_templates']['job_board']['features'] = features
+  end
 end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Chrome needs to not be installed on ppc64le. On that architecture, the feature should be removed from the job_board feature list. This has the effect that the chrome tests do not run on ppc64le.

## What approach did you choose and why?
Only run the installation steps when appropriate. Remove from feature list when necessary.

## How can you make sure the change works as expected?
Try it. Verify the chrome tests do not run on ppc64le.

## Would you like any additional feedback?
