### PR TITLE
Upgrade packages at start of chef run

### DIFF
--- a/cookbooks/travis_build_environment/recipes/apt.rb
+++ b/cookbooks/travis_build_environment/recipes/apt.rb
@@ -73,3 +73,7 @@ end
 execute 'apt-get update for travis_build_environment::apt' do
   command 'apt-get update'
 end
+
+execute 'apt-get upgrade for travis_build_environment::apt' do
+  command 'apt-get upgrade'
+end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
This is to speed up the apt packages installation. If all packages are upgraded in the start, we do not need to upgrade them one-by-one later on.

## What approach did you choose and why?

## How can you make sure the change works as expected?

## Would you like any additional feedback?
