### PR TITLE
Disable installation of firefox and mongodb on ppc64le

### DIFF
--- a/cookbooks/travis_build_environment/recipes/firefox.rb
+++ b/cookbooks/travis_build_environment/recipes/firefox.rb
@@ -35,16 +35,15 @@ ark 'firefox' do
   not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
-apt_repository "ubuntu-toolchain-r" do
-  uri "http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu"
-  distribution node['lsb']['codename']
-  components ["main"]
-  keyserver "keyserver.ubuntu.com"
-  key "BA9EF27F"
+package %w[firefox] do
+  action %i[install upgrade]
   only_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
-package %w[libstdc++6 firefox] do
-  action %i[install upgrade]
+ruby_block 'job_board adjustments firefox ppc64le' do
   only_if { node['kernel']['machine'] == 'ppc64le' }
+  block do
+    features = node['travis_packer_templates']['job_board']['features'] - ['firefox']
+    node.override['travis_packer_templates']['job_board']['features'] = features
+  end
 end

--- a/cookbooks/travis_build_environment/recipes/firefox.rb
+++ b/cookbooks/travis_build_environment/recipes/firefox.rb
@@ -35,7 +35,16 @@ ark 'firefox' do
   not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
-package %w[firefox] do
+apt_repository "ubuntu-toolchain-r" do
+  uri "http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu"
+  distribution node['lsb']['codename']
+  components ["main"]
+  keyserver "keyserver.ubuntu.com"
+  key "BA9EF27F"
+  only_if { node['kernel']['machine'] == 'ppc64le' }
+end
+
+package %w[libstdc++6 firefox] do
   action %i[install upgrade]
   only_if { node['kernel']['machine'] == 'ppc64le' }
 end

--- a/cookbooks/travis_build_environment/recipes/firefox.rb
+++ b/cookbooks/travis_build_environment/recipes/firefox.rb
@@ -35,11 +35,6 @@ ark 'firefox' do
   not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
-package %w[firefox] do
-  action %i[install upgrade]
-  only_if { node['kernel']['machine'] == 'ppc64le' }
-end
-
 ruby_block 'job_board adjustments firefox ppc64le' do
   only_if { node['kernel']['machine'] == 'ppc64le' }
   block do

--- a/cookbooks/travis_build_environment/recipes/mongodb.rb
+++ b/cookbooks/travis_build_environment/recipes/mongodb.rb
@@ -37,18 +37,6 @@ package 'mongodb-org' do
   not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
-package 'mongodb' do
-  notifies :stop, 'service[mongodb]', :immediately
-  notifies :disable, 'service[mongodb]', :immediately
-  only_if { node['kernel']['machine'] == 'ppc64le' }
-  not_if { node['travis_build_environment']['mongodb']['service_enabled'] }
-end
-
-service 'mongodb' do
-  action :nothing
-  only_if { node['kernel']['machine'] == 'ppc64le' }
-end
-
 service 'mongod' do
   action %i[stop disable]
   not_if { node['kernel']['machine'] == 'ppc64le' }

--- a/cookbooks/travis_build_environment/recipes/mongodb.rb
+++ b/cookbooks/travis_build_environment/recipes/mongodb.rb
@@ -60,3 +60,11 @@ apt_repository 'mongodb-4.0' do
   not_if { node['kernel']['machine'] == 'ppc64le' }
   not_if { node['travis_build_environment']['mongodb']['keep_repo'] }
 end
+
+ruby_block 'job_board adjustments mongodb ppc64le' do
+  only_if { node['kernel']['machine'] == 'ppc64le' }
+  block do
+    features = node['travis_packer_templates']['job_board']['features'] - ['mongodb']
+    node.override['travis_packer_templates']['job_board']['features'] = features
+  end
+end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Disable installation of firefox and mongodb on ppc64le

## What approach did you choose and why?
Installation is disabled using job-board feature.

## How can you make sure the change works as expected?
This change was tested locally and new image gets created as expected.

## Would you like any additional feedback?
