### PR TITLE
Install AGPL version of MongoDB

### DIFF
--- a/cookbooks/travis_build_environment/recipes/mongodb.rb
+++ b/cookbooks/travis_build_environment/recipes/mongodb.rb
@@ -33,10 +33,17 @@ apt_repository 'mongodb-4.0' do
   not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
-package 'mongodb-org' do
-  action :install
-  version '4.0.3'
-  not_if { node['kernel']['machine'] == 'ppc64le' }
+%w[
+  mongodb-org-mongos
+  mongodb-org-server
+  mongodb-org-shell
+  mongodb-org-tools
+].each do |p|
+  package p do
+    action :install
+    version '4.0.3'
+    not_if { node['kernel']['machine'] == 'ppc64le' }
+  end
 end
 
 package 'mongodb' do

--- a/cookbooks/travis_build_environment/recipes/mongodb.rb
+++ b/cookbooks/travis_build_environment/recipes/mongodb.rb
@@ -34,6 +34,8 @@ apt_repository 'mongodb-4.0' do
 end
 
 package 'mongodb-org' do
+  action :install
+  version '4.0.3'
   not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
This is the last version available before MongoDB git distributed under the SSPL license. This ensures that this version is installed.

## What approach did you choose and why?
Pinning the metapackage to 4.0.3 did *not* result in the child packages to be of the specified version.
This PR removes the metapackage `mongodb-org`, and installs its dependencies explicitly with version 4.0.3.

## How can you make sure the change works as expected?
Reviewed the files `/usr/share/doc/*mongo*/copyright`, which all state that the files are distributed under the AGPL license.

## Would you like any additional feedback?
