### PR TITLE
Drop deprecated `sudo` config in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: generic
 dist: trusty
-sudo: false
 
 env:
   global:


### PR DESCRIPTION
That config was deprecated for a while, ref:
https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures