### PR TITLE
php aliases

### DIFF
--- a/cookbooks/travis_build_environment/recipes/ci_user.rb
+++ b/cookbooks/travis_build_environment/recipes/ci_user.rb
@@ -301,8 +301,7 @@ node['travis_build_environment']['php_aliases'].each do |short_version, target_v
   link "#{phpenv_path}/versions/#{short_version}" do
     to "#{phpenv_path}/versions/#{target_version}"
     not_if do
-      Array(node['travis_build_environment']['php_versions']).empty? ||
-        ::File.exist?("#{phpenv_path}/versions/#{target_version}")
+      Array(node['travis_build_environment']['php_versions']).empty?
     end
   end
 end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Xenial images did not have PHP aliases set up for many of the preinstalled PHPs.

https://travis-ci.org/travis-infrastructure/packer-build/builds/485407594#L1799-L1804

This should fix it.

## What approach did you choose and why?

## How can you make sure the change works as expected?

## Would you like any additional feedback?
