### PR TITLE
fix openjdk-r installation

### DIFF
--- a/cookbooks/travis_java/recipes/openjdk-r.rb
+++ b/cookbooks/travis_java/recipes/openjdk-r.rb
@@ -2,8 +2,6 @@
 
 apt_repository 'openjdk-r-java-ppa' do
   uri 'ppa:openjdk-r/ppa'
-  distribution node['lsb']['codename']
-  components %w[main]
   retries 2
   retry_delay 30
   action :add

--- a/cookbooks/travis_java/recipes/openjdk-r.rb
+++ b/cookbooks/travis_java/recipes/openjdk-r.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 apt_repository 'openjdk-r-java-ppa' do
-  uri 'http://ppa.launchpad.net/openjdk-r/ppa/ubuntu'
+  uri 'ppa:openjdk-r/ppa'
   distribution node['lsb']['codename']
   components %w[main]
-  key '86F44E2A'
-  keyserver 'hkp://ha.pool.sks-keyservers.net'
   retries 2
   retry_delay 30
   action :add


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
key not found issue while installation of openjdk-r

## What approach did you choose and why?
added ppa:repo_name to the required recipe which verifies the key internally

## How can you make sure the change works as expected?
Verified by creating a new image locally.

## Would you like any additional feedback?
