### PR TITLE
git wireprotocol v2

### DIFF
--- a/cookbooks/travis_build_environment/templates/default/ci_user/dot_gitconfig.erb
+++ b/cookbooks/travis_build_environment/templates/default/ci_user/dot_gitconfig.erb
@@ -2,3 +2,5 @@
 [user]
 	name = <%= node['travis_build_environment']['user_comment'] %>
 	email = <%= node['travis_build_environment']['user_email'] %>
+[protocol]
+  version = 2

--- a/cookbooks/travis_build_environment/templates/default/ci_user/dot_gitconfig.erb
+++ b/cookbooks/travis_build_environment/templates/default/ci_user/dot_gitconfig.erb
@@ -3,4 +3,4 @@
 	name = <%= node['travis_build_environment']['user_comment'] %>
 	email = <%= node['travis_build_environment']['user_email'] %>
 [protocol]
-  version = 2
+	version = 2


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Use git wire protocol version 2. This should speed up clones in some situations.
Possibly obsoletes https://github.com/travis-ci/travis-build/pull/1659, as the required git version is not present on trusty and precise images.

## What approach did you choose and why?
Configure it.

## How can you make sure the change works as expected?
This should succeed on a resulting image:
```
GIT_TRACE=1 git pull 2>&1 | grep GIT_PROTOCOL=version=2
```

## Would you like any additional feedback?
To fix in images, or in travis-build? :grimacing: 