### PR TITLE
Apparmor service issue fix for ppc64le

### DIFF
--- a/cookbooks/travis_docker/files/default/etc/default/grub.d/99-travis-settings-ppc64le.cfg
+++ b/cookbooks/travis_docker/files/default/etc/default/grub.d/99-travis-settings-ppc64le.cfg
@@ -1,0 +1,4 @@
+# Managed by Chef, thanks!
+# Enable cgroup memory and swap accounting, disable apparmor
+GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1 apparmor=0 console=hvc0 console=tty"
+

--- a/cookbooks/travis_docker/recipes/default.rb
+++ b/cookbooks/travis_docker/recipes/default.rb
@@ -50,6 +50,14 @@ cookbook_file '/etc/default/grub.d/99-travis-settings.cfg' do
   not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
+cookbook_file '/etc/default/grub.d/99-travis-settings-ppc64le.cfg' do
+  source 'etc/default/grub.d/99-travis-settings-ppc64le.cfg'
+  owner 'root'
+  group 'root'
+  mode 0o640
+  only_if { node['kernel']['machine'] == 'ppc64le' }
+end
+
 execute 'update-grub' do
   only_if { node['travis_docker']['update_grub'] }
 end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Disable apprmor service on ppc64le and add custom console options in the grub config specific to ppc64le.

## What approach did you choose and why?
Created a custom template for ppc64le which contains arch specific changes.

## How can you make sure the change works as expected?
It was tested locally by creating new images.

## Would you like any additional feedback?
