### PR TITLE
Update default user to travis, ssh-key issue fix

### DIFF
--- a/cookbooks/travis_build_environment/templates/default/etc/cloud/cloud.cfg.erb
+++ b/cookbooks/travis_build_environment/templates/default/etc/cloud/cloud.cfg.erb
@@ -3,7 +3,13 @@
 ##     file:: templates/default/etc/cloud/cloud.cfg.erb
 
 users:
-- travis
+- default
+- name: ubuntu
+  lock_passwd: True
+  gecos: Ubuntu
+  groups: [adm, audio, cdrom, dialout, dip, floppy, netdev, plugdev, sudo, video]
+  sudo: ['ALL=(ALL) NOPASSWD:ALL']
+  shell: /bin/bash
 
 disable_root: true
 
@@ -63,9 +69,9 @@ cloud_final_modules:
 system_info:
   distro: ubuntu
   default_user:
-    name: ubuntu
+    name: travis
     lock_passwd: True
-    gecos: Ubuntu
+    gecos: Travis
     groups: [adm, audio, cdrom, dialout, dip, floppy, netdev, plugdev, sudo, video]
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     shell: /bin/bash


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The base images created using old cloud.cfg were not able to get new ssh keys provided during instance boot via openstack, this meant only single ssh key could be used to access the image which was used while the image creation. This PR sets the travis user as default user which allows the VM to get keys provided during instance boot.

## What approach did you choose and why?
Modified the cloud.cfg template to set travis user as the default user, this allows new ssh-keys to be added to travis user during instance boot.

## How can you make sure the change works as expected?
The changes were tested locally by creating new image and instance.

## Would you like any additional feedback?
