### PR TITLE
Wait for all emulators in android-wait-for-emulator script

### DIFF
--- a/community-cookbooks/android-sdk/files/default/android-wait-for-emulator
+++ b/community-cookbooks/android-sdk/files/default/android-wait-for-emulator
@@ -4,22 +4,28 @@
 
 set +e
 
-bootanim=""
-failcounter=0
-timeout_in_sec=360
+DEVICES=`adb devices | grep -v devices | grep device | cut -f 1`
 
-until [[ "$bootanim" =~ "stopped" ]]; do
-  bootanim=`adb -e shell getprop init.svc.bootanim 2>&1 &`
-  if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
-    || "$bootanim" =~ "running" ]]; then
-    let "failcounter += 1"
-    echo "Waiting for emulator to start"
-    if [[ $failcounter -gt timeout_in_sec ]]; then
-      echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
-      exit 1
-    fi
-  fi
-  sleep 1
+for device in $DEVICES; do
+    echo "$device $@ ..."
+
+    bootanim=""
+    failcounter=0
+    timeout_in_sec=360
+
+    until [[ "$bootanim" =~ "stopped" ]]; do
+      bootanim=`adb -s $device -e shell getprop init.svc.bootanim 2>&1 &`
+      if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
+        || "$bootanim" =~ "running" ]]; then
+        let "failcounter += 1"
+        echo "Waiting for emulator to start"
+        if [[ $failcounter -gt timeout_in_sec ]]; then
+          echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
+          exit 1
+        fi
+      fi
+      sleep 1
+    done
+
+    echo "Emulator is ready"
 done
-
-echo "Emulator is ready"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The script fails when there are multiple emulators running

## What approach did you choose and why?
I'm iterating through the emulator list and waiting for the boot logo completion for each emulator in order to wait for all emulator to finish loading.

## How can you make sure the change works as expected?
You can start multiple android emulators, run the script and check that it completes only when all emulators are ready.
