### PR TITLE
Change use of HTTP repo.maven.apache.org download location to HTTPS

### DIFF
--- a/cookbooks/travis_build_environment/files/default/ci_user/maven_user_settings.xml
+++ b/cookbooks/travis_build_environment/files/default/ci_user/maven_user_settings.xml
@@ -10,7 +10,7 @@
         <repository>
           <id>central</id>
           <name>Central Repository</name>
-          <url>http://repo.maven.apache.org/maven2</url>
+          <url>https://repo.maven.apache.org/maven2</url>
           <releases>
             <enabled>true</enabled>
           </releases>


### PR DESCRIPTION
Maven super pom defaults to https for a very long time now, see http://maven.apache.org/ref/3.6.0/maven-model-builder/super-pom.html

## What is the problem that this PR is trying to fix?

Default travis maven settings.xml file adds unsecured non-https maven repositories to the build.

## What approach did you choose and why?

Synchronize with what the default is doing.

## How can you make sure the change works as expected?

E.g. with this maven-enforcer-rule which fails on Travis, passes on normal installations.

```
<bannedRepositories>
    <bannedRepositories>http://*</bannedRepositories>
    <bannedPluginRepositories>http://*</bannedPluginRepositories>
</bannedRepositories>
```

## Would you like any additional feedback?

Whatever works for you guys.
