### PR TITLE
pin to an earlier tag release of kerl

### DIFF
--- a/cookbooks/travis_build_environment/recipes/kerl.rb
+++ b/cookbooks/travis_build_environment/recipes/kerl.rb
@@ -39,7 +39,7 @@ directory installation_root do
 end
 
 remote_file node['travis_build_environment']['kerl_path'] do
-  source 'https://raw.githubusercontent.com/spawngrid/kerl/master/kerl'
+  source 'https://raw.githubusercontent.com/kerl/kerl/1.8.5/kerl'
   mode 0o755
 end
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Kerl does not currently install due to a very recent change on master.

## What approach did you choose and why?

Pin to an earlier version