### PR TITLE
modify rvm install flags to use autolibs

### DIFF
--- a/cookbooks/travis_build_environment/recipes/rvm.rb
+++ b/cookbooks/travis_build_environment/recipes/rvm.rb
@@ -110,9 +110,9 @@ bash 'run rvm installer' do
   retry_delay 30
 end
 
-install_flag = "--autolibs=disable --binary --fuzzy"
+install_flag = "--autolibs=enable --fuzzy"
 if node['kernel']['machine'] == "ppc64le"
-  install_flag = "--autolibs=disable --fuzzy"
+  install_flag = "--autolibs=enable --fuzzy"
 end
 
 bash "install default ruby #{node['travis_build_environment']['default_ruby']}" do


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Enable autolibs of rvm and also disable binary only on x86. 
## What approach did you choose and why?
Turn off the switchs of installer's flags 
## How can you make sure the change works as expected?
It's been tested and work as expected 
## Would you like any additional feedback?
Yes