### PR TITLE
Update virtualenv to 16.3.0

### DIFF
--- a/cookbooks/travis_build_environment/recipes/virtualenv.rb
+++ b/cookbooks/travis_build_environment/recipes/virtualenv.rb
@@ -2,4 +2,4 @@
 
 include_recipe 'travis_build_environment::pip'
 
-execute 'pip install virtualenv==15.1.0'
+execute 'pip install virtualenv==16.3.0'


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

`DeprecationWarning` from the use of the deprecated `imp` module in Python 3.6 and 3.7.
- https://github.com/pypa/setuptools/issues/1933
- https://github.com/python-pillow/Pillow/issues/3547
- [https://stackoverflow.com/questions/55486248/deprecationwarning-in-python-3-6-and-3-7-with-pillow](https://stackoverflow.com/q/55486248/8601760)

From https://github.com/pypa/virtualenv/issues/955:

> The Python built-in module `imp` has been deprecated since Python 3.4. The `importlib` module should be used instead.

`virtualenv` embeds its own `distutils` via [virtualenv_embedded/distutils-init.py](https://github.com/pypa/virtualenv/blob/master/virtualenv_embedded/distutils-init.py).

Before `virtualenv==16.3.0`, the embedded `distutils` imported the deprecated `imp` module.
- 15.1.0: https://github.com/pypa/virtualenv/blob/15.1.0/virtualenv_embedded/distutils-init.py
- 16.3.0: https://github.com/pypa/virtualenv/blob/16.3.0/virtualenv_embedded/distutils-init.py

## What approach did you choose and why?

I chose to update the base version of `virtualenv` in **recipes/virtualenv.rb**.

Travis downloads the cached Python `virtualenv` (https://github.com/travis-ci/travis-cookbooks/pull/662, now done in **recipes/python.rb**), which is currently `16.6.0` for Python 3.6 and `16.7.8` for Python 3.7. However, the base version is still `15.1.0` and **/home/travis/virtualenv/python3.6.7/lib/python3.6/distutils/\_\_init\_\_.py** appears to be sourced from the base version of `virtualenv`. You can see these on Travis CI with **travis.yml**:

```yml
language: python
python:
  - "3.6"
sudo: required
dist: bionic
before_install:
   - virtualenv --version
   - deactivate
   - virtualenv --version
script:
  - python -W error::DeprecationWarning -c 'import distutils'
```

Output:

```
$ virtualenv --version
16.6.0
$ deactivate
$ virtualenv --version
15.1.0
```

## How can you make sure the change works as expected?

I tested that a new virtual env created with a base version of `16.3.0` works by running Travis CI locally ([https://stackoverflow.com/questions/21053657/how-to-run-travis-ci-locally#49019950](https://stackoverflow.com/a/49019950/8601760)).

Output, truncated for brevity:

```
/# cd /home/travis
/home/travis# virtualenv --version
15.1.0
/home/travis# source ./virtualenv/python3.6.7/bin/activate
(python3.6.7) /home/travis# virtualenv --version
16.6.0
(python3.6.7) /home/travis# python -W error::DeprecationWarning -c 'import distutils'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/distutils/__init__.py", line 4, in <module>
    import imp
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/imp.py", line 33, in <module>
    DeprecationWarning, stacklevel=2)
DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
(python3.6.7) /home/travis# deactivate
```
```
/home/travis# virtualenv --python=/opt/python/3.6.7/bin/python3.6.7 ./virtualenv/virtualenv15.1.0
/home/travis# source ./virtualenv/virtualenv15.1.0/bin/activate
(virtualenv15.1.0) /home/travis# python --version
Python 3.6.7
(virtualenv15.1.0) /home/travis# virtualenv --version
15.1.0
(virtualenv15.1.0) /home/travis# python -W error::DeprecationWarning -c 'import distutils'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/travis/virtualenv/virtualenv15.1.0/lib/python3.6/distutils/__init__.py", line 4, in <module>
    import imp
  File "/home/travis/virtualenv/virtualenv15.1.0/lib/python3.6/imp.py", line 33, in <module>
    DeprecationWarning, stacklevel=2)
DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
(virtualenv15.1.0) /home/travis# deactivate
```
```
/home/travis# pip install virtualenv==16.3.0
/home/travis# virtualenv --version
16.3.0
/home/travis# virtualenv --python=/opt/python/3.6.7/bin/python3.6.7 ./virtualenv/virtualenv16.3.0
/home/travis# source ./virtualenv/virtualenv16.3.0/bin/activate
(virtualenv16.3.0) /home/travis# python --version
Python 3.6.7
(virtualenv16.3.0) /home/travis# virtualenv --version
16.3.0
(virtualenv16.3.0) /home/travis# python -W error::DeprecationWarning -c 'import distutils'
(virtualenv16.3.0) /home/travis# deactivate
```

## Would you like any additional feedback?

Shall we upgrade to the latest `virtualenv==16.7.8`? https://github.com/pypa/virtualenv/releases