### PR TITLE
Update maven version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: generic
-dist: trusty
+dist: xenial
 
 env:
   global:
@@ -11,7 +11,7 @@ env:
 addons:
   apt:
     sources:
-    - sourceline: "deb https://packages.chef.io/repos/apt/current trusty main"
+    - sourceline: "deb https://packages.chef.io/repos/apt/current xenial main"
       key_url:  "https://%{app_host}/files/gpg/chef-current-trusty.asc"
     packages:
     - chefdk

--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -241,7 +241,7 @@ default['travis_build_environment']['sysctl_kernel_shmmax'] = 45_794_432
 default['travis_build_environment']['sysctl_disable_ipv6'] = true
 default['travis_build_environment']['sysctl_enable_ipv4_forwarding'] = true
 
-maven_version = '3.6.2'
+maven_version = '3.6.3'
 default['travis_build_environment']['maven_version'] = maven_version
 default['travis_build_environment']['maven_url'] = [
   'https://www.apache.org/dist/maven/maven-3/',

--- a/cookbooks/travis_jdk/recipes/default.rb
+++ b/cookbooks/travis_jdk/recipes/default.rb
@@ -69,7 +69,7 @@ apt_update do
 end
 
 apt_package 'default_java' do
-  package_name ['default-jre', 'default-jdk']
+  package_name %w[default-jre default-jdk]
 end
 
 versions.each do |jdk|


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

> [2019-12-17T11:25:00+00:00] ERROR: ark[maven] (travis_build_environment::maven line 3) had an error: Net::HTTPServerException: remote_file[/tmp/packer-chef-solo/local-mode-cache/cache/maven-3.6.2.tar.gz] (/tmp/packer-chef-solo/local-mode-cache/cache/cookbooks/ark/resources/default.rb line 62) had an error: Net::HTTPServerException: 404 "Not Found"

- Error with maven version
- Switch to xenial
- Small specs fix

## What approach did you choose and why?

## How can you make sure the change works as expected?

## Would you like any additional feedback?
