### PR TITLE
pip.rb: python3 get-pip.py

### DIFF
--- a/cookbooks/travis_build_environment/recipes/pip.rb
+++ b/cookbooks/travis_build_environment/recipes/pip.rb
@@ -10,6 +10,8 @@ bash 'install-pip' do
   cwd Chef::Config[:file_cache_path]
   code <<-INSTALL_PIP
     python3 get-pip.py
+    python2 get-pip.py
+    python get-pip.py
     pip install --upgrade pip setuptools wheel
   INSTALL_PIP
   not_if 'which pip'

--- a/cookbooks/travis_build_environment/recipes/pip.rb
+++ b/cookbooks/travis_build_environment/recipes/pip.rb
@@ -9,7 +9,7 @@ end
 bash 'install-pip' do
   cwd Chef::Config[:file_cache_path]
   code <<-INSTALL_PIP
-    python get-pip.py
+    python3 get-pip.py
     pip install --upgrade pip setuptools wheel
   INSTALL_PIP
   not_if 'which pip'


### PR DESCRIPTION
As requested by @native-api at https://github.com/travis-ci/docs-travis-ci-com/pull/2413#discussion_r410330159, now that [Python 2 is end of life](https://devguide.python.org/devcycle/#end-of-life-branches), let's use [Python 3](https://devguide.python.org/#status-of-python-branches) to install `pip`.

## What is the problem that this PR is trying to fix?
Python 2 is end of life so we should no longer default to pip installing Python packages with it.

## What approach did you choose and why?
Install with Python 3 which is the present and future of the language instead of Python 2 which has been legacy for years and is now end of life.

## How can you make sure the change works as expected?
This is has been common practice for years.

## Would you like any additional feedback?
If not now, why not??