### PR TITLE
Fix CouchDB installation on Xenial

### DIFF
--- a/cookbooks/travis_build_environment/recipes/couchdb.rb
+++ b/cookbooks/travis_build_environment/recipes/couchdb.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+
+node: lsb:trusty
+node: lsb:xenial
+node: lsb:bionic / a:1 
+
+
+for 1 - 10:
+  print oi
+
 case node['lsb']['codename']
 when 'trusty', 'xenial'
   apt_repository 'couchdb' do
@@ -39,9 +48,9 @@ when 'bionic'
     mode 0o644
   end
   execute "chown-couchdb" do
-  command "chown -R couchdb:couchdb /opt/couchdb/ -v"
-  user "root"
-  action :run
+    command "chown -R couchdb:couchdb /opt/couchdb/ -v"
+    user "root"
+    action :run
   end
 end
 

--- a/cookbooks/travis_build_environment/recipes/couchdb.rb
+++ b/cookbooks/travis_build_environment/recipes/couchdb.rb
@@ -1,14 +1,5 @@
 # frozen_string_literal: true
 
-
-node: lsb:trusty
-node: lsb:xenial
-node: lsb:bionic / a:1 
-
-
-for 1 - 10:
-  print oi
-
 case node['lsb']['codename']
 when 'trusty', 'xenial'
   apt_repository 'couchdb' do

--- a/cookbooks/travis_build_environment/recipes/couchdb.rb
+++ b/cookbooks/travis_build_environment/recipes/couchdb.rb
@@ -17,12 +17,6 @@ end
 
 package 'couchdb'
 
-execute "chown-couchdb" do
-  command "chown -R couchdb:couchdb /opt/couchdb/ -v"
-  user "root"
-  action :run
-end
-
 case node['lsb']['codename']
 when 'trusty', 'xenial'
   cookbook_file '/etc/couchdb/local.d/erlang_query_server.ini' do
@@ -43,6 +37,11 @@ when 'bionic'
     owner 'couchdb'
     group 'couchdb'
     mode 0o644
+  end
+  execute "chown-couchdb" do
+  command "chown -R couchdb:couchdb /opt/couchdb/ -v"
+  user "root"
+  action :run
   end
 end
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
CouchDB installation on Xenial

## What approach did you choose and why?
CouchDB only uses /opt/ on newer versions, now checking the OS version on the recipe.

## How can you make sure the change works as expected?

## Would you like any additional feedback?
