### PR TITLE
Only install CMake from an official tarball for AMD64

### DIFF
--- a/cookbooks/travis_build_environment/recipes/cmake.rb
+++ b/cookbooks/travis_build_environment/recipes/cmake.rb
@@ -33,10 +33,10 @@ ark 'cmake' do
   retries 2
   retry_delay 30
   append_env_path true
-  not_if { node['kernel']['machine'] == 'ppc64le' }
+  only_if { node['kernel']['machine'] == 'amd64' }
 end
 
 package 'cmake' do
   action %i[install upgrade]
-  only_if { node['kernel']['machine'] == 'ppc64le' }
+  not_if { node['kernel']['machine'] == 'amd64' }
 end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

https://travis-ci.community/t/wrong-binary-format-for-cmake-installed-as-an-addon-on-arm64-graviton2/10697

All architectures except `amd64` and `ppc64le` are affected.

## What approach did you choose and why?

Only install CMake from and `_x86_64` tarball on `amd64`, use `upgrade` on other architecture as is already being done on `ppc64le`

## How can you make sure the change works as expected?

`cmake --version` works rather than produce "`cannot execute binary file: Exec format error`"

## Would you like any additional feedback?
