### PR TITLE
Don't start sbt with MaxPermSize

### DIFF
--- a/cookbooks/travis_sbt_extras/templates/default/jvmopts.erb
+++ b/cookbooks/travis_sbt_extras/templates/default/jvmopts.erb
@@ -4,5 +4,4 @@
 -Xms2048M
 -Xmx2048M
 -Xss6M
--XX:MaxPermSize=512M
 


### PR DESCRIPTION
Java 17 early access builds removed support for `MaxPermSize`, see https://github.com/openjdk/jdk/commit/1e77896838e15c334c9f5e0eaa17c23b321b5ca8
It was ignored since Java 8 anyway... 
Also it was removed from the Java cookbook long time ago already: f55eebf52c456dbd2d65cd88a8011e1be5f66cc6