### PR TITLE
Update jq to 1.6

### DIFF
--- a/cookbooks/travis_build_environment/recipes/jq.rb
+++ b/cookbooks/travis_build_environment/recipes/jq.rb
@@ -27,7 +27,7 @@
 arch = node['kernel']['machine'] =~ /x86_64/ ? '64' : '32'
 
 remote_file node['travis_build_environment']['jq_install_dest'] do
-  source "https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux#{arch}"
+  source "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux#{arch}"
   action :create_if_missing
   mode 0o755
   owner node['travis_build_environment']['owner']


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
jq 1.6 was released [in 2018](https://github.com/stedolan/jq/releases/tag/jq-1.6), but Travis CI still has 1.5.
This fixes #1091.

## What approach did you choose and why?
Just update the source link, one character change.

## How can you make sure the change works as expected?
Check the version in CI? 🤷‍♂️ I don't expect any problems, but I apologize if there are some, this seems straightforward to me.

## Would you like any additional feedback?
Sure.