### PR TITLE
Update cookbook to fix failures on ppc64le

### DIFF
--- a/cookbooks/travis_build_environment/recipes/apt.rb
+++ b/cookbooks/travis_build_environment/recipes/apt.rb
@@ -75,5 +75,5 @@ execute 'apt-get update for travis_build_environment::apt' do
 end
 
 execute 'apt-get upgrade for travis_build_environment::apt' do
-  command 'apt-get upgrade'
+  command 'DEBIAN_FRONTEND=noninteractive apt-get upgrade -y'
 end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The cookbook fails to run on ppc64le due to 
- `elasticsearch` install which is not available on ppc64le
- dialog error during `apt upgrade`
## What approach did you choose and why?
- Skip `elasticsearch` on ppc64le.
- Add `DEBIAN_FRONTEND=noninteractive` to resolve dialog error.

