### PR TITLE
Install noarch elasticsearch deb on ppc64le

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -188,6 +188,12 @@ default['travis_build_environment']['sphinxsearch']['ppas'] = %w(
 version = '7.16.3'
 default['travis_build_environment']['elasticsearch']['version'] = version
 default['travis_build_environment']['elasticsearch']['package_name'] = "elasticsearch-#{version}-#{default['travis_build_environment']['arch']}.deb"
+# Latest versions of elasticsearch provide arch specific deb files which are not available for ppc64le
+# Use noarch elasticsearch deb file for ppc64le
+if node['kernel']['machine'] == 'ppc64le'
+  default['travis_build_environment']['elasticsearch']['version'] = '6.8.23'
+  default['travis_build_environment']['elasticsearch']['package_name'] = "elasticsearch-#{version}.deb"
+end
 default['travis_build_environment']['elasticsearch']['service_enabled'] = false
 default['travis_build_environment']['elasticsearch']['jvm_heap'] = '128m'
 

--- a/cookbooks/travis_build_environment/recipes/elasticsearch.rb
+++ b/cookbooks/travis_build_environment/recipes/elasticsearch.rb
@@ -10,7 +10,6 @@ remote_file deb_download_dest do
   source "https://artifacts.elastic.co/downloads/elasticsearch/#{package_name}"
   owner node['travis_build_environment']['user']
   group node['travis_build_environment']['group']
-  not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
 dpkg_package package_name do
@@ -18,7 +17,6 @@ dpkg_package package_name do
   notifies :run, 'ruby_block[create-symbolic-links]'
   action :install
   not_if 'which elasticsearch'
-  not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
 ruby_block 'create-symbolic-links' do
@@ -33,7 +31,6 @@ ruby_block 'create-symbolic-links' do
     end
   end
   action :nothing
-  not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
 template '/etc/elasticsearch/jvm.options' do
@@ -44,7 +41,6 @@ template '/etc/elasticsearch/jvm.options' do
   variables(
     jvm_heap: node['travis_build_environment']['elasticsearch']['jvm_heap']
   )
-  not_if { node['kernel']['machine'] == 'ppc64le' }
 end
 
 service 'elasticsearch' do
@@ -55,13 +51,4 @@ service 'elasticsearch' do
   end
   retries 4
   retry_delay 30
-  not_if { node['kernel']['machine'] == 'ppc64le' }
-end
-
-ruby_block 'job_board adjustments elasticsearch ppc64le' do
-  only_if { node['kernel']['machine'] == 'ppc64le' }
-  block do
-    features = node['travis_packer_templates']['job_board']['features'] - ['elasticsearch']
-    node.override['travis_packer_templates']['job_board']['features'] = features
-  end
 end


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Latest releases of elasticsearch provide arch specific deb file which is not available on ppc64le and causes build failure. Hence install of elasticsearch was skipped on ppc64le in 7ee72dc277292f1eebb6c93eac118074e5fdd5c3. However based on recent investigation, older versions of elasticsearch provided `all` arch deb files and it was used to install `5.5.0` version of elasticsearch in ppc64le images. 
## What approach did you choose and why?
Use noarch deb file of version `6.8.23` to install elasticsearch on ppc64le. All latest versions after `6.8.23` are released in arch specific manner.
