### PR TITLE
Update shfmt to v3.9.0

### DIFF
--- a/cookbooks/travis_build_environment/attributes/default.rb
+++ b/cookbooks/travis_build_environment/attributes/default.rb
@@ -282,8 +282,8 @@ default['travis_build_environment']['shellcheck_version'] = '0.10.0'
 default['travis_build_environment']['shellcheck_checksum'] = '6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87'
 default['travis_build_environment']['shellcheck_binaries'] = %w(shellcheck)
 
-default['travis_build_environment']['shfmt_url'] = 'https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64'
-default['travis_build_environment']['shfmt_checksum'] = '27b3c6f9d9592fc5b4856c341d1ff2c88856709b9e76469313642a1d7b558fe0'
+default['travis_build_environment']['shfmt_url'] = 'https://github.com/mvdan/sh/releases/download/v3.9.0/shfmt_v3.9.0_linux_amd64'
+default['travis_build_environment']['shfmt_checksum'] = 'd99b06506aee2ac9113daec3049922e70dc8cffb84658e3ae512c6a6cbe101b6'
 
 default['travis_build_environment']['yarn_url'] = 'https://yarnpkg.com/latest.tar.gz'
 default['travis_build_environment']['yarn_version'] = 'latest'


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

`shfmt` not up to date, the latest version has been release for about two months, should be good to update it

## What approach did you choose and why?

Download the latest release and check its checksum, update `cookbooks/travis_build_environment/attributes/default.rb`

## How can you make sure the change works as expected?

Just as how I did it many times before?

## Would you like any additional feedback?

no

## Reference

https://github.com/mvdan/sh/releases/tag/v3.9.0